### PR TITLE
feat(runner): restore chunk-stream layout and visible player

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,187 @@
+SHELL := /bin/bash
+.DEFAULT_GOAL := help
+
+PYTHON ?= python3
+BASH ?= bash
+
+REPO ?= $(GITHUB_REPOSITORY)
+LABELS_FILE ?= config/project/labels.json
+MILESTONES_FILE ?= config/project/milestones.json
+PROJECT_FILE ?= config/project/project-definition.json
+BACKLOG_FILE ?= config/stories/backlog-manifest.json
+PROJECT_NUMBER ?=
+OWNER ?=
+ISSUE_NUMBER ?=
+ISSUE_STATE ?= open
+TITLE ?=
+BODY ?=
+BODY_FILE ?=
+LABELS ?=
+ADD_LABELS ?=
+REMOVE_LABELS ?=
+DRY_RUN ?= true
+LINK_SUBISSUES ?= false
+CLEAR_NOT_PLANNED ?= false
+ONLY_LINK_SUBISSUES ?= false
+RUN_LABELS ?= true
+RUN_MILESTONES ?= true
+RUN_PROJECT ?= true
+RUN_ISSUES ?= true
+
+define require_repo
+	@test -n "$(REPO)" || { echo "Missing REPO. Set REPO or GITHUB_REPOSITORY."; exit 1; }
+endef
+
+define require_issue_number
+	@test -n "$(ISSUE_NUMBER)" || { echo "Missing ISSUE_NUMBER."; exit 1; }
+endef
+
+define require_project_number
+	@test -n "$(PROJECT_NUMBER)" || { echo "Missing PROJECT_NUMBER."; exit 1; }
+endef
+
+define require_title
+	@test -n "$(TITLE)" || { echo "Missing TITLE."; exit 1; }
+endef
+
+.PHONY: help labels_sync milestones_sync project_create project_sync issues_generate issue_milestones_sync auto_label_apply bootstrap_local issue_create issue_update issue_delete
+
+help:
+	@printf '%s\n' \
+		'Governance make targets:' \
+		'  make labels_sync' \
+		'  make milestones_sync' \
+		'  make project_create' \
+		'  make project_sync PROJECT_NUMBER=123' \
+		'  make issues_generate' \
+		'  make issue_milestones_sync' \
+		'  make auto_label_apply EVENT_PATH=/path/to/event.json' \
+		'  make bootstrap_local' \
+		'  make issue_create TITLE="..." BODY_FILE=... LABELS="status:backlog type:task"' \
+		'  make issue_update ISSUE_NUMBER=123 TITLE="..." ADD_LABELS="priority:high"' \
+		'  make issue_delete ISSUE_NUMBER=123' \
+		'' \
+		'Common variables:' \
+		'  REPO, LABELS_FILE, MILESTONES_FILE, PROJECT_FILE, BACKLOG_FILE' \
+		'  DRY_RUN=true|false, LINK_SUBISSUES=true|false' \
+		'  RUN_LABELS=true|false, RUN_MILESTONES=true|false, RUN_PROJECT=true|false, RUN_ISSUES=true|false' \
+		'  ADD_LABELS and REMOVE_LABELS accept space- or comma-separated lists'
+
+labels_sync:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/labels/sync.py --repo "$(REPO)" --file "$(LABELS_FILE)"); \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+milestones_sync:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/milestones/sync.py --repo "$(REPO)" --file "$(MILESTONES_FILE)"); \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+project_create:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/project/create.py "$(PROJECT_FILE)" --repo "$(REPO)"); \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+project_sync:
+	$(call require_repo)
+	$(call require_project_number)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/project/sync.py "$(PROJECT_FILE)" --repo "$(REPO)" --project-number "$(PROJECT_NUMBER)" --issue-state "$(ISSUE_STATE)"); \
+	if [[ -n "$(OWNER)" ]]; then args+=(--owner "$(OWNER)"); fi; \
+	if [[ "$(LINK_SUBISSUES)" == "true" ]]; then args+=(--link-subissues); fi; \
+	if [[ "$(ONLY_LINK_SUBISSUES)" == "true" ]]; then args+=(--only-link-subissues); fi; \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+issues_generate:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/issues/generate.py "$(BACKLOG_FILE)" --repo "$(REPO)"); \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	if [[ "$(DRY_RUN)" == "false" && "$(LINK_SUBISSUES)" == "true" ]]; then args+=(--link-subissues); fi; \
+	"$${args[@]}"
+
+issue_milestones_sync:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/issue_milestones/sync.py --repo "$(REPO)"); \
+	if [[ "$(CLEAR_NOT_PLANNED)" == "true" ]]; then args+=(--clear-not-planned); fi; \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+auto_label_apply:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(PYTHON) scripts/github/auto_label/apply.py --repo "$(REPO)"); \
+	if [[ -n "$(EVENT_PATH)" ]]; then args+=(--event-path "$(EVENT_PATH)"); fi; \
+	if [[ -n "$(LABELS_FILE)" ]]; then args+=(--labels-file "$(LABELS_FILE)"); fi; \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); fi; \
+	"$${args[@]}"
+
+bootstrap_local:
+	$(call require_repo)
+	@set -euo pipefail; \
+	args=($(BASH) scripts/github/bootstrap/local.sh --repo "$(REPO)"); \
+	if [[ "$(DRY_RUN)" == "true" ]]; then args+=(--dry-run); else args+=(--no-dry-run); fi; \
+	if [[ "$(RUN_LABELS)" == "false" ]]; then args+=(--skip-labels); fi; \
+	if [[ "$(RUN_MILESTONES)" == "false" ]]; then args+=(--skip-milestones); fi; \
+	if [[ "$(RUN_PROJECT)" == "false" ]]; then args+=(--skip-project); fi; \
+	if [[ "$(RUN_ISSUES)" == "false" ]]; then args+=(--skip-issues); fi; \
+	if [[ "$(LINK_SUBISSUES)" == "true" ]]; then args+=(--link-subissues); fi; \
+	"$${args[@]}"
+
+issue_create:
+	$(call require_repo)
+	$(call require_title)
+	@set -euo pipefail; \
+	cmd=(gh issue create --repo "$(REPO)" --title "$(TITLE)"); \
+	if [[ -n "$(BODY_FILE)" ]]; then \
+		cmd+=(--body-file "$(BODY_FILE)"); \
+	else \
+		cmd+=(--body "$(BODY)"); \
+	fi; \
+	add_labels() { \
+		local raw="$${1:-}"; \
+		raw="$${raw//,/ }"; \
+		for item in $$raw; do \
+			[[ -n "$$item" ]] && cmd+=(--label "$$item"); \
+		done; \
+	}; \
+	add_labels "$(LABELS)"; \
+	"$${cmd[@]}"
+
+issue_update:
+	$(call require_repo)
+	$(call require_issue_number)
+	@set -euo pipefail; \
+	cmd=(gh issue edit "$(ISSUE_NUMBER)" --repo "$(REPO)"); \
+	if [[ -n "$(TITLE)" ]]; then \
+		cmd+=(--title "$(TITLE)"); \
+	fi; \
+	if [[ -n "$(BODY_FILE)" ]]; then \
+		cmd+=(--body-file "$(BODY_FILE)"); \
+	elif [[ -n "$(BODY)" ]]; then \
+		cmd+=(--body "$(BODY)"); \
+	fi; \
+	add_labels() { \
+		local flag="$${1:-}"; \
+		local raw="$${2:-}"; \
+		raw="$${raw//,/ }"; \
+		for item in $$raw; do \
+			[[ -n "$$item" ]] && cmd+=("$$flag" "$$item"); \
+		done; \
+	}; \
+	add_labels --add-label "$(ADD_LABELS)"; \
+	add_labels --remove-label "$(REMOVE_LABELS)"; \
+	"$${cmd[@]}"
+
+issue_delete:
+	$(call require_repo)
+	$(call require_issue_number)
+	@gh issue delete "$(ISSUE_NUMBER)" --repo "$(REPO)" --yes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,22 @@ Take Your Pills - É um jogo infinity runner, side-scroller, ambientado em um Ja
 - Artefatos de governança: `/docs`, `/config`, `/.github`, `/scripts`
 - Runbook de bootstrap: `/docs/repo/governance-bootstrap-runbook.pt-BR.md`
 - CLI reutilizável: `python -m governance_bootstrap`
+- Make targets: `make help`
 - Guia de contribuição: `/CONTRIBUTING.md`
+
+## Make shortcuts
+Use os atalhos abaixo para a rotina de governança:
+
+```bash
+make labels_sync
+make milestones_sync
+make project_create
+make issues_generate
+
+make issue_create REPO=v-Kaefer/Take-Your-Pills TITLE="New issue" BODY_FILE=/tmp/body.md LABELS="status:backlog type:task"
+make issue_update REPO=v-Kaefer/Take-Your-Pills ISSUE_NUMBER=123 TITLE="Updated title" ADD_LABELS="priority:high"
+make issue_delete REPO=v-Kaefer/Take-Your-Pills ISSUE_NUMBER=123
+```
 
 ## Verificação local (full verify)
 Use estes comandos antes de abrir/atualizar PR:

--- a/config/stories/backlog-manifest.json
+++ b/config/stories/backlog-manifest.json
@@ -31,27 +31,27 @@
       "stories": [
         {
           "storyId": "US-01",
-          "title": "US-01 | Implementar corrida lateral contínua e base de movimentação",
+          "title": "US-01 | Implementar fluxo de chunks com player fixo",
           "labels": ["type:user-story", "priority:critical", "test:smoke"],
-          "body": "Como jogador, quero controlar uma corrida lateral contínua para que o jogo tenha um loop base imediatamente compreensível.",
+          "body": "Como jogador, quero um fluxo de chunks sob um player fixo para que o jogo tenha um loop base imediatamente compreensível.",
           "acceptanceCriteria": [
-            "o personagem entra em corrida automática assim que a run começa",
-            "o deslocamento horizontal é contínuo e estável",
+            "o fluxo de chunks entra em movimento assim que a run começa",
+            "o deslocamento horizontal do cenário é contínuo e estável",
             "a velocidade base vem de uma única fonte de configuração",
-            "não existe input manual para andar para frente ou para trás",
-            "pausa e game over interrompem totalmente o auto-run"
+            "o player permanece ancorado e não recebe input manual de deslocamento horizontal",
+            "pausa e game over interrompem totalmente o fluxo de chunks"
           ],
           "testStrategy": [
             "executar o smoke check do projeto Godot em modo headless",
-            "abrir a cena Game e verificar que o player corre sem input",
-            "ativar pausa e confirmar que o movimento é interrompido",
-            "encerrar a run e confirmar que o auto-run não continua",
-            "verificar que não há caminho de controle horizontal manual"
+            "abrir a cena Game e verificar que os chunks se movem sem mover o player",
+            "ativar pausa e confirmar que o fluxo é interrompido",
+            "encerrar a run e confirmar que o fluxo não continua",
+            "verificar que não há caminho de controle horizontal manual do player"
           ],
           "dod": [
             "cena Player criada e instanciável",
-            "auto-run integrado à cena Game",
-            "estados básicos impedem movimento em pause e dead",
+            "fluxo de chunks integrado à cena Game",
+            "estados básicos impedem o fluxo em pause e dead",
             "evidência de validação manual registrada"
           ],
           "tasks": [
@@ -65,7 +65,7 @@
               "completionCriteria": [
                 "a cena Player instancia sem erros",
                 "a cena possui base visual e colisão",
-                "o arquivo está pronto para receber o auto-run"
+                "o arquivo está pronto para receber o fluxo fixo de chunks e enquadramento"
               ],
               "testStrategy": [
                 "abrir a cena Player diretamente no editor",
@@ -82,30 +82,30 @@
               ]
             },
             {
-              "title": "T-01.2 | Implementar corrida automática",
+              "title": "T-01.2 | Implementar fluxo de chunks",
               "technicalScope": [
-                "implementar deslocamento horizontal automático na atualização física",
+                "implementar deslocamento horizontal automático nos chunks e nas camadas do cenário",
                 "ler a velocidade a partir de uma configuração única",
-                "impedir movimento para trás",
-                "parar a movimentação quando o estado não estiver ativo"
+                "manter o player fixo no eixo horizontal",
+                "parar o fluxo quando o estado não estiver ativo"
               ],
               "completionCriteria": [
-                "o player se move automaticamente enquanto a run estiver ativa",
+                "o cenário se move automaticamente enquanto a run estiver ativa",
                 "a velocidade horizontal responde a uma configuração central",
-                "o personagem não aceita deslocamento horizontal manual",
-                "pause e game over interrompem o auto-run"
+                "o player não aceita deslocamento horizontal manual",
+                "pause e game over interrompem o fluxo"
               ],
               "testStrategy": [
                 "executar uma run em Game sem pressionar input horizontal",
-                "pausar a run e confirmar que o avanço para",
+                "pausar a run e confirmar que o fluxo para",
                 "finalizar a run e confirmar que o movimento cessa"
               ],
               "expectedEvidence": [
-                "observação manual do movimento automático",
+                "observação manual do fluxo automático",
                 "anotação ou captura de pausa e game over interrompendo o avanço"
               ],
               "dod": [
-                "auto-run funcionando no fluxo principal",
+                "fluxo funcionando no fluxo principal",
                 "movimento controlado por uma fonte de velocidade única",
                 "parada confiável em pause e dead"
               ]
@@ -116,7 +116,7 @@
                 "definir os estados mínimos running, paused e dead",
                 "rotear o input principal através da camada de estado",
                 "reservar o ponto de entrada para o input de pulo sem implementar física de pulo",
-                "garantir que input em pause e dead não altere o auto-run"
+                "garantir que input em pause e dead não altere o fluxo dos chunks"
               ],
               "completionCriteria": [
                 "o player expõe estados básicos claros",
@@ -127,7 +127,7 @@
               "testStrategy": [
                 "acionar input durante running e confirmar que o estado responde",
                 "acionar input durante pause e dead e confirmar que não há efeito",
-                "validar que o estado não quebra a corrida automática"
+                "validar que o estado não quebra o fluxo dos chunks"
               ],
               "expectedEvidence": [
                 "registro dos estados e do fluxo de input",
@@ -140,30 +140,33 @@
               ]
             },
             {
-              "title": "T-01.4 | Conectar player à cena Game",
+              "title": "T-01.4 | Conectar player e chunks à cena Game",
               "technicalScope": [
                 "instanciar o player a partir da cena Game",
+                "instanciar o fluxo de chunks a partir da cena Game",
                 "fazer a Game assumir o ciclo de vida da run",
-                "garantir que pause e game over desativem o player de forma consistente",
-                "manter o player independente da lógica de cena fora do movimento"
+                "garantir que pause e game over desativem o fluxo de forma consistente",
+                "manter o player independente da lógica de chunks"
               ],
               "completionCriteria": [
                 "a cena Game cria o player corretamente",
+                "a cena Game cria o fluxo de chunks corretamente",
                 "a run começa já em estado jogável",
-                "pause e game over afetam o player como esperado",
-                "a responsabilidade entre Game e Player fica separada"
+                "pause e game over afetam o fluxo como esperado",
+                "a responsabilidade entre Game, Player e mapa fica separada"
               ],
               "testStrategy": [
-                "abrir a cena Game e confirmar que o player aparece e corre",
-                "pausar a cena e confirmar que a corrida para",
-                "encerrar a run e confirmar que o player não continua ativo"
+                "abrir a cena Game e confirmar que o player aparece enquanto os chunks correm",
+                "pausar a cena e confirmar que o fluxo para",
+                "encerrar a run e confirmar que os chunks não continuam ativos"
               ],
               "expectedEvidence": [
-                "captura da cena Game com o player em execução",
+                "captura da cena Game com os chunks em execução",
                 "registro da verificação de pause e game over"
               ],
               "dod": [
                 "player conectado à cena Game",
+                "chunks conectados à cena Game",
                 "ciclo de vida da run centralizado em Game",
                 "integração pronta para as próximas histórias da fase"
               ]
@@ -186,10 +189,10 @@
         },
         {
           "storyId": "US-04",
-          "title": "US-04 | Implementar cenário inicial, câmera e instanciação básica",
+          "title": "US-04 | Implementar cenário inicial com chunks",
           "labels": ["type:user-story", "priority:high", "test:smoke"],
-          "body": "Como jogador, quero um cenário inicial legível para compreender o espaço de jogo e o movimento.",
-          "tasks": ["T-04.1 | Criar cena do cenário inicial", "T-04.2 | Implementar câmera 2D", "T-04.3 | Instanciar obstáculos básicos", "T-04.4 | Ajustar layout inicial para leitura"]
+          "body": "Como jogador, quero um cenário inicial legível com chunks para compreender o espaço de jogo e o movimento.",
+          "tasks": ["T-04.1 | Criar cena do cenário inicial", "T-04.2 | Fixar player no enquadramento", "T-04.3 | Instanciar chunks e obstáculos básicos", "T-04.4 | Ajustar layout inicial para leitura"]
         },
         {
           "storyId": "US-05",

--- a/docs/phases/phase-01.md
+++ b/docs/phases/phase-01.md
@@ -1,7 +1,7 @@
 # Phase 1 — Playable foundation
 
 ## Objective
-Reach core runner loop and first checkpoint baseline.
+Reach the core runner loop and first checkpoint baseline with streamed chunks and the player anchored in a fixed view.
 
 ## Included scope
 - US-01..US-05
@@ -17,7 +17,7 @@ Reach core runner loop and first checkpoint baseline.
 
 ## Test criteria
 - Smoke tests for movement/jump/collision/restart
-- Manual readability checks for HUD and camera
+- Manual readability checks for HUD and chunk-stream framing
 
 ## Phase DoD
 - Core loop playable and stable

--- a/docs/repo/governance-bootstrap.workflow-template.yml
+++ b/docs/repo/governance-bootstrap.workflow-template.yml
@@ -1,0 +1,53 @@
+name: Governance bootstrap (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without writing to GitHub"
+        required: true
+        default: true
+        type: boolean
+      run_project_creation:
+        description: "Create GitHub Project v2"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout consumer repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install governance CLI
+        run: |
+          python -m pip install "git+https://github.com/OWNER/github-governance-bootstrap.git@v0.1.0"
+
+      - name: Run bootstrap
+        env:
+          GITHUB_TOKEN: ${{ secrets.GOVERNANCE_PAT }}
+          GH_TOKEN: ${{ secrets.GOVERNANCE_PAT }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          args="--config governance.bootstrap.json"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            args="$args --dry-run"
+          else
+            args="$args --no-dry-run --link-subissues"
+          fi
+          if [ "${{ inputs.run_project_creation }}" = "true" ]; then
+            args="$args --run-project-creation"
+          fi
+          governance bootstrap $args

--- a/docs/repo/governance-shared-tool.md
+++ b/docs/repo/governance-shared-tool.md
@@ -1,0 +1,40 @@
+# Shared Governance Tool
+
+This repository now carries the reusable bootstrap engine as the Python package `governance_bootstrap`.
+
+## What Is Generic
+- GitHub label sync from `config/project/labels.json`.
+- GitHub milestone sync from `config/project/milestones.json`.
+- GitHub Project v2 creation and issue sync from `config/project/project-definition.json`.
+- Issue/task generation from `config/stories/backlog-manifest.json`.
+- Auto-label and issue milestone helpers.
+
+## What Stays Project-Specific
+- Label names and colors.
+- Milestone names and dates.
+- Project board name, fields, options, views and `phaseMilestoneMap`.
+- Backlog phases, user stories, tasks and default labels.
+- The target repository passed with `--repo owner/repo`.
+
+## Consumer Setup
+1. Copy `governance.bootstrap.json`, `config/project`, `config/stories` and the workflow into the consumer repo.
+2. Add a repository secret named `GOVERNANCE_PAT`.
+3. Give the token access to repo issues and Project v2 operations.
+4. Run the manual workflow with `dry_run=true`.
+5. Run again with `dry_run=false` when the dry-run output is correct.
+
+Use `docs/repo/governance-bootstrap.workflow-template.yml` as the consumer workflow template after publishing this package in its own repository. Replace `OWNER/github-governance-bootstrap` with the final shared-tool repository.
+
+Local dry-run:
+
+```bash
+export GH_TOKEN=...
+python -m governance_bootstrap bootstrap --repo owner/repo --dry-run
+```
+
+Real bootstrap:
+
+```bash
+export GH_TOKEN=...
+python -m governance_bootstrap bootstrap --repo owner/repo --no-dry-run --link-subissues
+```

--- a/governance.bootstrap.json
+++ b/governance.bootstrap.json
@@ -1,0 +1,15 @@
+{
+  "labelsFile": "config/project/labels.json",
+  "milestonesFile": "config/project/milestones.json",
+  "projectDefinitionFile": "config/project/project-definition.json",
+  "backlogManifestFile": "config/stories/backlog-manifest.json",
+  "secretName": "GOVERNANCE_PAT",
+  "defaults": {
+    "dryRun": true,
+    "runLabels": true,
+    "runMilestones": true,
+    "runProjectCreation": false,
+    "runIssueGeneration": true,
+    "linkSubissues": true
+  }
+}

--- a/governance_bootstrap/__init__.py
+++ b/governance_bootstrap/__init__.py
@@ -1,0 +1,4 @@
+"""Reusable GitHub governance bootstrap tooling."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/governance_bootstrap/__main__.py
+++ b/governance_bootstrap/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/governance_bootstrap/auto_label.py
+++ b/governance_bootstrap/auto_label.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+import re
+
+from .github import API_BASE, GitHubRequestError, GitHubClient
+
+
+LABEL_PREFIXES = ("type:", "priority:", "test:")
+
+
+def load_event(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_allowed_labels(path: str) -> set[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        return {item["name"] for item in json.load(f)}
+
+
+def label_names(item: dict) -> set[str]:
+    return {label["name"] for label in item.get("labels", [])}
+
+
+def find_test_label(text: str) -> str | None:
+    patterns = [
+        r"Test strategy\s*\n+\s*(automated|smoke|manual)\b",
+        r"Expected test type\s*\n+\s*(automated|smoke|manual)\b",
+        r"Test type:\s*(automated|smoke|manual)\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return f"test:{match.group(1).lower()}"
+    return None
+
+
+def find_priority_label(text: str) -> str | None:
+    match = re.search(r"Severity\s*\n+\s*(critical|high|medium|low)\b", text, re.IGNORECASE)
+    return f"priority:{match.group(1).lower()}" if match else None
+
+
+def title_type_label(title: str) -> str | None:
+    if re.match(r"^US-\d+", title, re.IGNORECASE):
+        return "type:user-story"
+    if re.match(r"^T-\d+", title, re.IGNORECASE):
+        return "type:task"
+    if re.match(r"^BUG\b", title, re.IGNORECASE):
+        return "type:bug"
+    return None
+
+
+def linked_issue_number(text: str) -> int | None:
+    match = re.search(r"\b(?:closes|fixes|resolves)\s+#(\d+)\b", text, re.IGNORECASE)
+    return int(match.group(1)) if match else None
+
+
+def labels_from_linked_issue(client: GitHubClient, repo: str, number: int) -> set[str]:
+    issue = client.request_json("GET", f"{API_BASE}/repos/{repo}/issues/{number}")
+    return {name for name in label_names(issue) if name.startswith(LABEL_PREFIXES)}
+
+
+def branch_type_label(branch: str) -> str | None:
+    prefix = branch.split("/", 1)[0].lower()
+    if prefix in {"fix", "hotfix"}:
+        return "type:bug"
+    if prefix in {"docs", "refactor", "test"}:
+        return "type:repo"
+    return None
+
+
+def infer_issue_labels(issue: dict) -> set[str]:
+    current = label_names(issue)
+    body = issue.get("body") or ""
+    labels = set()
+
+    type_label = next((label for label in current if label.startswith("type:")), None)
+    labels.add(type_label or title_type_label(issue.get("title", "")) or "")
+
+    priority_label = find_priority_label(body)
+    if priority_label:
+        labels.add(priority_label)
+
+    test_label = find_test_label(body)
+    if test_label:
+        labels.add(test_label)
+
+    if not any(label.startswith("status:") for label in current):
+        labels.add("status:backlog")
+
+    return {label for label in labels if label}
+
+
+def infer_pr_labels(repo: str, pr: dict, client: GitHubClient | None) -> set[str]:
+    body = pr.get("body") or ""
+    labels = set()
+
+    number = linked_issue_number(body)
+    if number and client:
+        try:
+            labels.update(labels_from_linked_issue(client, repo, number))
+        except GitHubRequestError as exc:
+            print(f"warning: could not read linked issue #{number}: {exc}")
+
+    test_label = find_test_label(body)
+    if test_label:
+        labels.add(test_label)
+
+    if not any(label.startswith("type:") for label in labels):
+        type_label = branch_type_label(pr.get("head", {}).get("ref", ""))
+        if type_label:
+            labels.add(type_label)
+
+    return labels
+
+
+def event_target(event: dict) -> tuple[str, dict, int]:
+    if "issue" in event and "pull_request" not in event["issue"]:
+        return "issue", event["issue"], event["issue"]["number"]
+    if "pull_request" in event:
+        return "pull_request", event["pull_request"], event["pull_request"]["number"]
+    raise RuntimeError("Unsupported event payload: expected issue or pull_request")
+
+
+def apply_auto_labels(repo: str, event_path: str, labels_file: str, client: GitHubClient | None, dry_run: bool = False) -> int:
+    event = load_event(event_path)
+    allowed = load_allowed_labels(labels_file)
+    target_type, item, number = event_target(event)
+    current = label_names(item)
+
+    inferred = infer_issue_labels(item) if target_type == "issue" else infer_pr_labels(repo, item, client)
+    labels = sorted(label for label in inferred if label in allowed and label not in current)
+    if not labels:
+        print(f"No labels to add for {target_type} #{number}")
+        return 0
+
+    print(f"Labels to add to {target_type} #{number}: {', '.join(labels)}")
+    if dry_run:
+        return 0
+    if not client:
+        print("Missing GITHUB_TOKEN or GH_TOKEN")
+        return 1
+
+    try:
+        client.request_json("POST", f"{API_BASE}/repos/{repo}/issues/{number}/labels", {"labels": labels})
+    except GitHubRequestError as exc:
+        if exc.status == 403:
+            print(f"warning: token cannot add labels to {target_type} #{number}; skipping")
+            return 0
+        raise
+    return 0

--- a/governance_bootstrap/cli.py
+++ b/governance_bootstrap/cli.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from .auto_label import apply_auto_labels
+from .github import GitHubClient, get_token, require_client
+from .issue_milestones import sync_issue_milestones
+from .issues import generate_issues
+from .labels import sync_labels
+from .milestones import sync_milestones
+from .project import create_project, sync_project
+
+
+def load_bootstrap_config(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def repo_arg(value: str | None) -> str:
+    repo = value or os.getenv("GITHUB_REPOSITORY")
+    if not repo:
+        raise SystemExit("Missing --repo and GITHUB_REPOSITORY")
+    return repo
+
+
+def optional_client() -> GitHubClient | None:
+    token = get_token()
+    return GitHubClient(token) if token else None
+
+
+def cmd_labels_sync(args) -> int:
+    client = GitHubClient("") if args.dry_run else require_client()
+    sync_labels(client, repo_arg(args.repo), args.file, dry_run=args.dry_run)
+    return 0
+
+
+def cmd_milestones_sync(args) -> int:
+    client = GitHubClient("") if args.dry_run else require_client()
+    sync_milestones(client, repo_arg(args.repo), args.file, dry_run=args.dry_run)
+    return 0
+
+
+def cmd_issues_generate(args) -> int:
+    generate_issues(repo_arg(args.repo), args.file, dry_run=args.dry_run, link_subissues=args.link_subissues)
+    return 0
+
+
+def cmd_project_create(args) -> int:
+    client = GitHubClient("") if args.dry_run else require_client()
+    create_project(client, repo_arg(args.repo), args.file, dry_run=args.dry_run)
+    return 0
+
+
+def cmd_project_sync(args) -> int:
+    sync_project(
+        require_client(),
+        repo_arg(args.repo),
+        args.file,
+        args.project_number,
+        owner=args.owner,
+        issue_state=args.issue_state,
+        link_subissue_items=args.link_subissues,
+        only_link_subissues=args.only_link_subissues,
+        dry_run=args.dry_run,
+    )
+    return 0
+
+
+def cmd_issue_milestones_sync(args) -> int:
+    sync_issue_milestones(require_client(), repo_arg(args.repo), clear_not_planned=args.clear_not_planned, dry_run=args.dry_run)
+    return 0
+
+
+def cmd_auto_label_apply(args) -> int:
+    event_path = args.event_path or os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("Missing --event-path or GITHUB_EVENT_PATH")
+        return 1
+    return apply_auto_labels(repo_arg(args.repo), event_path, args.labels_file, optional_client(), dry_run=args.dry_run)
+
+
+def cmd_bootstrap(args) -> int:
+    config = load_bootstrap_config(args.config)
+    defaults = config.get("defaults", {})
+    dry_run = args.dry_run if args.dry_run is not None else defaults.get("dryRun", True)
+    repo = repo_arg(args.repo)
+    client = GitHubClient("") if dry_run else require_client()
+
+    run_labels = args.run_labels if args.run_labels is not None else defaults.get("runLabels", True)
+    run_milestones = args.run_milestones if args.run_milestones is not None else defaults.get("runMilestones", True)
+    run_project_creation = args.run_project_creation if args.run_project_creation is not None else defaults.get("runProjectCreation", False)
+    run_issue_generation = args.run_issue_generation if args.run_issue_generation is not None else defaults.get("runIssueGeneration", True)
+    link_subissues = args.link_subissues if args.link_subissues is not None else defaults.get("linkSubissues", False)
+
+    if run_labels:
+        print("==> Sync labels")
+        sync_labels(client, repo, config["labelsFile"], dry_run=dry_run)
+    if run_milestones:
+        print("==> Sync milestones")
+        sync_milestones(client, repo, config["milestonesFile"], dry_run=dry_run)
+    if run_project_creation:
+        print("==> Create project v2")
+        create_project(client, repo, config["projectDefinitionFile"], dry_run=dry_run)
+    if run_issue_generation:
+        print("==> Generate issues/tasks")
+        generate_issues(repo, config["backlogManifestFile"], dry_run=dry_run, link_subissues=link_subissues and not dry_run)
+
+    print("Governance bootstrap finished.")
+    return 0
+
+
+def add_bool_pair(parser: argparse.ArgumentParser, name: str, dest: str, help_text: str) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(f"--{name}", dest=dest, action="store_true", default=None, help=help_text)
+    group.add_argument(f"--skip-{name.removeprefix('run-')}", dest=dest, action="store_false")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="governance", description="Reusable GitHub governance bootstrap CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    labels = sub.add_parser("labels")
+    labels_sub = labels.add_subparsers(dest="labels_command", required=True)
+    labels_sync = labels_sub.add_parser("sync")
+    labels_sync.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    labels_sync.add_argument("--file", default="config/project/labels.json")
+    labels_sync.add_argument("--dry-run", action="store_true")
+    labels_sync.set_defaults(func=cmd_labels_sync)
+
+    milestones = sub.add_parser("milestones")
+    milestones_sub = milestones.add_subparsers(dest="milestones_command", required=True)
+    milestones_sync = milestones_sub.add_parser("sync")
+    milestones_sync.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    milestones_sync.add_argument("--file", default="config/project/milestones.json")
+    milestones_sync.add_argument("--dry-run", action="store_true")
+    milestones_sync.set_defaults(func=cmd_milestones_sync)
+
+    issues = sub.add_parser("issues")
+    issues_sub = issues.add_subparsers(dest="issues_command", required=True)
+    issues_generate = issues_sub.add_parser("generate")
+    issues_generate.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    issues_generate.add_argument("--file", default="config/stories/backlog-manifest.json")
+    issues_generate.add_argument("--dry-run", action="store_true")
+    issues_generate.add_argument("--link-subissues", action="store_true")
+    issues_generate.set_defaults(func=cmd_issues_generate)
+
+    project = sub.add_parser("project")
+    project_sub = project.add_subparsers(dest="project_command", required=True)
+    project_create = project_sub.add_parser("create")
+    project_create.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    project_create.add_argument("--file", default="config/project/project-definition.json")
+    project_create.add_argument("--dry-run", action="store_true")
+    project_create.set_defaults(func=cmd_project_create)
+
+    project_sync = project_sub.add_parser("sync")
+    project_sync.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    project_sync.add_argument("--owner")
+    project_sync.add_argument("--file", default="config/project/project-definition.json")
+    project_sync.add_argument("--project-number", type=int, required=True)
+    project_sync.add_argument("--issue-state", default="open", choices=["open", "closed", "all"])
+    project_sync.add_argument("--link-subissues", action="store_true")
+    project_sync.add_argument("--only-link-subissues", action="store_true")
+    project_sync.add_argument("--dry-run", action="store_true")
+    project_sync.set_defaults(func=cmd_project_sync)
+
+    issue_milestones = sub.add_parser("issue-milestones")
+    issue_milestones_sub = issue_milestones.add_subparsers(dest="issue_milestones_command", required=True)
+    issue_milestones_sync = issue_milestones_sub.add_parser("sync")
+    issue_milestones_sync.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    issue_milestones_sync.add_argument("--clear-not-planned", action="store_true")
+    issue_milestones_sync.add_argument("--dry-run", action="store_true")
+    issue_milestones_sync.set_defaults(func=cmd_issue_milestones_sync)
+
+    auto_label = sub.add_parser("auto-label")
+    auto_label_sub = auto_label.add_subparsers(dest="auto_label_command", required=True)
+    auto_label_apply = auto_label_sub.add_parser("apply")
+    auto_label_apply.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    auto_label_apply.add_argument("--event-path", default=os.getenv("GITHUB_EVENT_PATH"))
+    auto_label_apply.add_argument("--labels-file", default="config/project/labels.json")
+    auto_label_apply.add_argument("--dry-run", action="store_true")
+    auto_label_apply.set_defaults(func=cmd_auto_label_apply)
+
+    bootstrap = sub.add_parser("bootstrap")
+    bootstrap.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY"))
+    bootstrap.add_argument("--config", default="governance.bootstrap.json")
+    dry_run_group = bootstrap.add_mutually_exclusive_group()
+    dry_run_group.add_argument("--dry-run", dest="dry_run", action="store_true", default=None)
+    dry_run_group.add_argument("--no-dry-run", dest="dry_run", action="store_false")
+    add_bool_pair(bootstrap, "run-labels", "run_labels", "Run labels sync")
+    add_bool_pair(bootstrap, "run-milestones", "run_milestones", "Run milestones sync")
+    add_bool_pair(bootstrap, "run-project-creation", "run_project_creation", "Create project v2")
+    add_bool_pair(bootstrap, "run-issue-generation", "run_issue_generation", "Generate issues/tasks")
+    link_group = bootstrap.add_mutually_exclusive_group()
+    link_group.add_argument("--link-subissues", dest="link_subissues", action="store_true", default=None)
+    link_group.add_argument("--no-link-subissues", dest="link_subissues", action="store_false")
+    bootstrap.set_defaults(func=cmd_bootstrap)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/governance_bootstrap/github.py
+++ b/governance_bootstrap/github.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+API_BASE = "https://api.github.com"
+GRAPHQL_URL = f"{API_BASE}/graphql"
+API_VERSION = "2022-11-28"
+RETRYABLE_HTTP_STATUS = {502, 503, 504}
+
+
+class GitHubRequestError(RuntimeError):
+    def __init__(self, method: str, url: str, status: int, details: str):
+        super().__init__(f"GitHub API request failed ({method} {url}) status={status}: {details}")
+        self.method = method
+        self.url = url
+        self.status = status
+        self.details = details
+
+
+def get_token() -> str | None:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
+def split_repo(repo: str) -> tuple[str, str]:
+    if "/" not in repo:
+        raise ValueError("repository must use owner/name format")
+    return repo.split("/", 1)
+
+
+class GitHubClient:
+    def __init__(self, token: str):
+        self.token = token
+
+    def request_json(self, method: str, url: str, payload=None, accept: str = "application/vnd.github+json"):
+        headers = {
+            "Accept": accept,
+            "Authorization": f"Bearer {self.token}",
+            "X-GitHub-Api-Version": API_VERSION,
+            "Content-Type": "application/json",
+        }
+        data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        for attempt in range(1, 6):
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            try:
+                with urllib.request.urlopen(req) as res:
+                    body = res.read().decode("utf-8")
+                    return json.loads(body) if body else {}
+            except urllib.error.HTTPError as exc:
+                details = exc.read().decode("utf-8", errors="replace")
+                if exc.code in RETRYABLE_HTTP_STATUS and attempt < 5:
+                    wait_seconds = attempt * 2
+                    print(f"warning: HTTP {exc.code} from GitHub; retrying in {wait_seconds}s")
+                    time.sleep(wait_seconds)
+                    continue
+                raise GitHubRequestError(method, url, exc.code, details) from exc
+            except urllib.error.URLError as exc:
+                if attempt < 5:
+                    wait_seconds = attempt * 2
+                    print(f"warning: GitHub request failed; retrying in {wait_seconds}s: {exc.reason}")
+                    time.sleep(wait_seconds)
+                    continue
+                raise
+
+    def list_issue_comments(self, repo: str, number: int):
+        return self.paginated(f"{API_BASE}/repos/{repo}/issues/{number}/comments")
+
+    def create_issue_comment(self, repo: str, number: int, body: str):
+        return self.request_json("POST", f"{API_BASE}/repos/{repo}/issues/{number}/comments", {"body": body})
+
+    def update_issue_comment(self, repo: str, comment_id: int, body: str):
+        return self.request_json("PATCH", f"{API_BASE}/repos/{repo}/issues/comments/{comment_id}", {"body": body})
+
+    def delete_issue_comment(self, repo: str, comment_id: int):
+        return self.request_json("DELETE", f"{API_BASE}/repos/{repo}/issues/comments/{comment_id}")
+
+    def paginated(self, url: str):
+        items = []
+        page = 1
+        while True:
+            sep = "&" if "?" in url else "?"
+            batch = self.request_json("GET", f"{url}{sep}per_page=100&page={page}")
+            items.extend(batch)
+            if len(batch) < 100:
+                return items
+            page += 1
+
+    def graphql(self, query: str, variables: dict | None = None):
+        data = self.request_json("POST", GRAPHQL_URL, {"query": query, "variables": variables or {}})
+        if data.get("errors"):
+            raise RuntimeError(f"GraphQL error: {json.dumps(data['errors'], ensure_ascii=False)}")
+        return data["data"]
+
+
+def require_client() -> GitHubClient:
+    token = get_token()
+    if not token:
+        raise SystemExit("Missing GITHUB_TOKEN or GH_TOKEN")
+    return GitHubClient(token)

--- a/governance_bootstrap/issue_milestones.py
+++ b/governance_bootstrap/issue_milestones.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import re
+
+from .github import API_BASE, GitHubClient, split_repo
+
+
+def milestone_from_body(body: str) -> str | None:
+    match = re.search(r"-\s*Milestone:\s*([A-Za-z0-9_.-]+)", body or "")
+    return match.group(1) if match else None
+
+
+def parent_issue_number_from_body(body: str) -> int | None:
+    match = re.search(r"Parent story:.*\(#(\d+)\)", body or "")
+    return int(match.group(1)) if match else None
+
+
+def sync_issue_milestones(client: GitHubClient, repo: str, clear_not_planned: bool = False, dry_run: bool = False) -> None:
+    owner, name = split_repo(repo)
+    repo_base = f"{API_BASE}/repos/{owner}/{name}"
+
+    milestones = client.paginated(f"{repo_base}/milestones?state=all")
+    milestone_by_title = {milestone["title"]: milestone for milestone in milestones}
+    issues = [
+        issue
+        for issue in client.paginated(f"{repo_base}/issues?state=all&sort=created&direction=asc")
+        if "pull_request" not in issue
+    ]
+
+    explicit_milestone_by_issue = {}
+    for issue in issues:
+        milestone = milestone_from_body(issue.get("body") or "")
+        if milestone:
+            explicit_milestone_by_issue[issue["number"]] = milestone
+
+    updated = 0
+    cleared = 0
+    already_correct = 0
+    unmapped = []
+
+    for issue in issues:
+        issue_number = issue["number"]
+        current = issue.get("milestone")
+        current_title = current["title"] if current else None
+
+        if clear_not_planned and issue.get("state") == "closed" and issue.get("state_reason") == "not_planned":
+            if current_title:
+                if dry_run:
+                    print(f"[DRY-RUN] Would clear milestone from not-planned issue #{issue_number}: {current_title}")
+                else:
+                    client.request_json("PATCH", f"{repo_base}/issues/{issue_number}", {"milestone": None})
+                    print(f"cleared #{issue_number}: {current_title}")
+                cleared += 1
+            else:
+                already_correct += 1
+            continue
+
+        target = explicit_milestone_by_issue.get(issue_number)
+        if not target:
+            parent_number = parent_issue_number_from_body(issue.get("body") or "")
+            if parent_number:
+                target = explicit_milestone_by_issue.get(parent_number)
+
+        if not target:
+            unmapped.append((issue_number, issue["title"]))
+            continue
+
+        milestone = milestone_by_title.get(target)
+        if not milestone:
+            raise RuntimeError(f"Milestone '{target}' referenced by issue #{issue_number} does not exist")
+
+        if current_title == target:
+            already_correct += 1
+            continue
+
+        if dry_run:
+            print(f"[DRY-RUN] Would set issue #{issue_number}: {current_title or 'none'} -> {target}")
+        else:
+            client.request_json("PATCH", f"{repo_base}/issues/{issue_number}", {"milestone": milestone["number"]})
+            print(f"updated #{issue_number}: {current_title or 'none'} -> {target}")
+        updated += 1
+
+    print(f"issues_checked={len(issues)}")
+    print(f"updated={updated}")
+    print(f"cleared_not_planned={cleared}")
+    print(f"already_correct={already_correct}")
+    print(f"unmapped={len(unmapped)}")
+    for issue_number, title in unmapped:
+        print(f"unmapped #{issue_number}: {title}")

--- a/governance_bootstrap/issues.py
+++ b/governance_bootstrap/issues.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+
+def run_gh(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"GitHub command failed. stderr:\n{result.stderr}")
+    return result.stdout.strip()
+
+
+def create_issue(repo: str, title: str, body: str, labels: list[str]) -> int:
+    cmd = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in labels:
+        cmd += ["--label", label]
+    url = run_gh(cmd)
+    parts = url.rstrip("/").split("/")
+    if len(parts) < 2 or not parts[-1].isdigit():
+        raise RuntimeError(f"Unexpected gh issue create output: {url}")
+    return int(parts[-1])
+
+
+def issue_node_id(repo: str, number: int) -> str:
+    owner, name = repo.split("/", 1)
+    return run_gh([
+        "gh", "api", "graphql",
+        "-f", "query=query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){id}}}",
+        "-f", f"owner={owner}",
+        "-f", f"repo={name}",
+        "-F", f"number={number}",
+        "--jq", ".data.repository.issue.id",
+    ])
+
+
+def add_sub_issue(repo: str, parent_number: int, child_number: int) -> None:
+    parent_id = issue_node_id(repo, parent_number)
+    child_id = issue_node_id(repo, child_number)
+    run_gh([
+        "gh", "api", "graphql",
+        "-f", "query=mutation($parent:ID!,$child:ID!){addSubIssue(input:{issueId:$parent,subIssueId:$child}){clientMutationId}}",
+        "-f", f"parent={parent_id}",
+        "-f", f"child={child_id}",
+    ])
+
+
+def load_backlog(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if "phases" not in data:
+        raise ValueError("backlog manifest must contain phases")
+    return data
+
+
+def render_section_content(content: str | list[str] | None, fallback: str = "- TBD") -> str:
+    if content is None:
+        return fallback
+    if isinstance(content, str):
+        stripped = content.strip()
+        return stripped or fallback
+    if isinstance(content, list):
+        if not content:
+            return fallback
+        return "\n".join(f"- {item}" for item in content)
+    raise TypeError(f"Unsupported section content type: {type(content)!r}")
+
+
+def render_section(title: str, content: str | list[str] | None, fallback: str = "- TBD") -> str:
+    return f"## {title}\n{render_section_content(content, fallback)}\n\n"
+
+
+def task_title(task: str | dict) -> str:
+    if isinstance(task, str):
+        return task
+    title = task.get("title")
+    if not title:
+        raise ValueError("task objects must include a title")
+    return title
+
+
+def task_labels(task: str | dict) -> list[str]:
+    labels = ["type:task", "status:backlog"]
+    if isinstance(task, dict):
+        labels.extend(task.get("labels", []))
+    return list(dict.fromkeys(labels))
+
+
+def task_body(story: dict, story_num: int, task: str | dict) -> str:
+    parent_ref = f"Parent story: {story['storyId']}"
+    if story_num:
+        parent_ref += f" (#{story_num})"
+
+    if isinstance(task, str):
+        return (
+            f"{parent_ref}\n\n"
+            + "## Technical scope\n- TBD\n\n"
+            + "## Completion criteria\n- TBD\n\n"
+            + "## Test strategy\n- TBD\n\n"
+            + "## Expected evidence\n- TBD\n\n"
+            + "## Definition of Done\n- TBD\n\n"
+            + "- Item type: task/sub-issue\n"
+        )
+
+    return (
+        f"{parent_ref}\n\n"
+        + render_section("Technical scope", task.get("technicalScope"))
+        + render_section("Completion criteria", task.get("completionCriteria"))
+        + render_section("Test strategy", task.get("testStrategy"))
+        + render_section("Expected evidence", task.get("expectedEvidence"))
+        + render_section("Definition of Done", task.get("dod"))
+        + "- Item type: task/sub-issue\n"
+    )
+
+
+def generate_issues(repo: str, manifest: str, dry_run: bool = False, link_subissues: bool = False) -> None:
+    if not repo:
+        repo = os.getenv("GITHUB_REPOSITORY", "")
+    if not repo:
+        raise SystemExit("Missing --repo and GITHUB_REPOSITORY")
+
+    data = load_backlog(manifest)
+    for phase in data["phases"]:
+        for story in phase["stories"]:
+            story_labels = list(dict.fromkeys(story["labels"] + data.get("defaultIssueLabels", [])))
+            story_body = (
+                f"{story['body']}\n\n"
+                + render_section("Acceptance criteria", story.get("acceptanceCriteria"))
+                + render_section("Test strategy", story.get("testStrategy"))
+                + render_section("Definition of Done", story.get("dod"))
+                + f"- Milestone: {phase['milestone']}\n"
+                + f"- Item type: user-story\n"
+            )
+            if dry_run:
+                print(f"[DRY-RUN] Story: {story['title']} labels={story_labels}")
+                story_num = 0
+            else:
+                story_num = create_issue(repo, story["title"], story_body, story_labels)
+                print(f"Created story #{story_num}: {story['title']}")
+
+            for task in story.get("tasks", []):
+                current_task_title = task_title(task)
+                current_task_labels = task_labels(task)
+                current_task_body = task_body(story, story_num, task)
+                if dry_run:
+                    print(f"[DRY-RUN]   Task: {current_task_title} labels={current_task_labels}")
+                    continue
+                task_num = create_issue(repo, current_task_title, current_task_body, current_task_labels)
+                print(f"  Created task #{task_num}: {current_task_title}")
+                if link_subissues:
+                    add_sub_issue(repo, story_num, task_num)
+                    print(f"    Linked #{task_num} as sub-issue of #{story_num}")

--- a/governance_bootstrap/labels.py
+++ b/governance_bootstrap/labels.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import urllib.parse
+
+from .github import API_BASE, GitHubRequestError, GitHubClient, split_repo
+
+
+def load_labels(path: str) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        labels = json.load(f)
+    if not isinstance(labels, list):
+        raise ValueError("labels manifest must be a JSON list")
+    for label in labels:
+        for key in ("name", "color"):
+            if key not in label:
+                raise ValueError(f"label is missing required key: {key}")
+    return labels
+
+
+def sync_labels(client: GitHubClient, repo: str, labels_file: str, dry_run: bool = False) -> None:
+    owner, name = split_repo(repo)
+    labels = load_labels(labels_file)
+    base = f"{API_BASE}/repos/{owner}/{name}/labels"
+
+    if dry_run:
+        print(f"[DRY-RUN] Would sync {len(labels)} labels to {repo}")
+        for label in labels:
+            print(f"- {label['name']}")
+        return
+
+    for label in labels:
+        try:
+            client.request_json("POST", base, label)
+            print(f"created: {label['name']}")
+        except GitHubRequestError as exc:
+            if exc.status != 422:
+                raise
+            patch_url = f"{base}/{urllib.parse.quote(label['name'])}"
+            client.request_json("PATCH", patch_url, label)
+            print(f"updated: {label['name']}")

--- a/governance_bootstrap/milestones.py
+++ b/governance_bootstrap/milestones.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+from .github import API_BASE, GitHubClient, split_repo
+
+
+def load_milestones(path: str) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as f:
+        milestones = json.load(f)
+    if not isinstance(milestones, list):
+        raise ValueError("milestones manifest must be a JSON list")
+    for milestone in milestones:
+        if "title" not in milestone:
+            raise ValueError("milestone is missing required key: title")
+    return milestones
+
+
+def sync_milestones(client: GitHubClient, repo: str, milestones_file: str, dry_run: bool = False) -> None:
+    owner, name = split_repo(repo)
+    milestones = load_milestones(milestones_file)
+
+    if dry_run:
+        print(f"[DRY-RUN] Would sync {len(milestones)} milestones to {repo}")
+        for milestone in milestones:
+            print(f"- {milestone['title']} ({milestone.get('due_on', 'no-due-date')})")
+        return
+
+    base = f"{API_BASE}/repos/{owner}/{name}/milestones"
+    existing = client.request_json("GET", f"{base}?state=all&per_page=100")
+    existing_by_title = {item["title"]: item for item in existing}
+
+    for milestone in milestones:
+        payload = {
+            "title": milestone["title"],
+            "description": milestone.get("description", ""),
+        }
+        if milestone.get("due_on"):
+            payload["due_on"] = milestone["due_on"]
+
+        current = existing_by_title.get(milestone["title"])
+        if current:
+            client.request_json("PATCH", f"{base}/{current['number']}", payload)
+            print(f"updated: {milestone['title']}")
+            continue
+
+        client.request_json("POST", base, payload)
+        print(f"created: {milestone['title']}")

--- a/governance_bootstrap/pr_validation.py
+++ b/governance_bootstrap/pr_validation.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from .github import GitHubClient
+
+
+VALIDATION_MARKER = "<!-- governance-pr-validation -->"
+BRANCH_PATTERN = re.compile(r"^(feat|fix|docs|refactor|test|hotfix|phase|task)\/[a-z0-9._/-]+$")
+
+REQUIRED_SECTIONS = [
+    ("linked issue", "Linked Issue"),
+    ("milestone", "Milestone"),
+    ("summary", "Summary"),
+    ("how to test", "How to test"),
+    ("evidence", "Evidence"),
+    ("known risks", "Known risks"),
+    ("dod checklist", "DoD checklist"),
+]
+
+PLACEHOLDER_PATTERNS = [
+    re.compile(r"^\s*[-*_]\s*$"),
+    re.compile(r"\b(todo|tbd|placeholder|example|describe|replace me|fill in)\b", re.IGNORECASE),
+    re.compile(r"<[^>]+>"),
+]
+
+
+@dataclass(frozen=True)
+class ValidationFinding:
+    section: str
+    problem: str
+    fix: str
+
+
+def normalize_header(header: str) -> str:
+    return " ".join(header.strip().lower().split())
+
+
+def sections_from_body(body: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current = None
+    for line in body.splitlines():
+        match = re.match(r"^##\s+(.+?)\s*$", line)
+        if match:
+            current = normalize_header(match.group(1))
+            sections.setdefault(current, [])
+            continue
+        if current:
+            sections[current].append(line)
+    return sections
+
+
+def line_is_placeholder(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return True
+    return any(pattern.search(stripped) for pattern in PLACEHOLDER_PATTERNS)
+
+
+def meaningful_lines(lines: list[str]) -> list[str]:
+    values = []
+    for line in lines:
+        if line_is_placeholder(line):
+            continue
+        values.append(line.strip())
+    return values
+
+
+def validate_branch_name(branch: str | None) -> list[ValidationFinding]:
+    if not branch or not branch.strip():
+        return [
+            ValidationFinding(
+                section="Branch name",
+                problem="Branch name is missing.",
+                fix="Use an approved prefix such as `feat/...`, `fix/...`, `docs/...`, `refactor/...`, `test/...`, `hotfix/...`, `phase/...`, or `task/...`.",
+            )
+        ]
+
+    branch = branch.strip()
+    if BRANCH_PATTERN.fullmatch(branch):
+        return []
+
+    return [
+        ValidationFinding(
+            section="Branch name",
+            problem=f"Invalid branch name `{branch}`.",
+            fix="Rename it to the repository pattern, for example `feat/repo-governance-bootstrap` or `task/phase-1/player-base`.",
+        )
+    ]
+
+
+def has_concrete_steps(lines: list[str]) -> bool:
+    saw_steps = False
+    for line in lines:
+        match = re.match(r"^\s*steps:\s*(.*?)\s*$", line, re.IGNORECASE)
+        if match:
+            saw_steps = True
+            remainder = match.group(1).strip()
+            if remainder and not line_is_placeholder(remainder):
+                return True
+            continue
+        if saw_steps and not line_is_placeholder(line):
+            return True
+    return False
+
+
+def validate_pr_body(body: str | None) -> list[ValidationFinding]:
+    body = body or ""
+    if not body.strip():
+        return [
+            ValidationFinding(
+                section="PR body",
+                problem="The PR body is blank.",
+                fix="Start from `.github/pull_request_template.md` and fill all required sections: Linked Issue, Milestone, Summary, How to test, Evidence, Known risks, and DoD checklist.",
+            )
+        ]
+
+    sections = sections_from_body(body)
+    findings: list[ValidationFinding] = []
+
+    for key, label in REQUIRED_SECTIONS:
+        lines = sections.get(key)
+        if lines is None:
+            findings.append(
+                ValidationFinding(
+                    section=label,
+                    problem="Section is missing.",
+                    fix=f"Add a `## {label}` section and fill it with concrete content.",
+                )
+            )
+            continue
+        if not meaningful_lines(lines):
+            findings.append(
+                ValidationFinding(
+                    section=label,
+                    problem="Section is empty or still a placeholder.",
+                    fix=f"Replace the placeholder text in `## {label}` with the real information for this PR.",
+                )
+            )
+
+    linked_issue = "\n".join(sections.get("linked issue", []))
+    if linked_issue and not re.search(r"\b(closes|fixes|resolves)\s+#\d+\b", linked_issue, re.IGNORECASE):
+        findings.append(
+            ValidationFinding(
+                section="Linked Issue",
+                problem="The section does not contain a linked issue reference.",
+                fix="Write `Closes #123`, `Fixes #123`, or `Resolves #123` inside `## Linked Issue`.",
+            )
+        )
+
+    milestone = "\n".join(sections.get("milestone", []))
+    if milestone and not re.search(r"\bMS[0-6]\b", milestone, re.IGNORECASE):
+        findings.append(
+            ValidationFinding(
+                section="Milestone",
+                problem="The milestone is missing or invalid.",
+                fix="Use a milestone like `MS0`, `MS1`, or the milestone assigned to this delivery.",
+            )
+        )
+
+    how_to_test_lines = sections.get("how to test", [])
+    how_to_test = "\n".join(how_to_test_lines)
+    if how_to_test_lines:
+        if not re.search(r"test type:\s*(automated|smoke|manual)\b", how_to_test, re.IGNORECASE):
+            findings.append(
+                ValidationFinding(
+                    section="How to test",
+                    problem="The test type is missing or invalid.",
+                    fix="Add `Test type: automated`, `Test type: smoke`, or `Test type: manual`.",
+                )
+            )
+        if not has_concrete_steps(how_to_test_lines):
+            findings.append(
+                ValidationFinding(
+                    section="How to test",
+                    problem="The test steps are missing or still placeholder text.",
+                    fix="Describe the exact commands, manual flow, or verification steps under `Steps:`.",
+                )
+            )
+
+    return findings
+
+
+def validate_pull_request(branch: str | None, body: str | None) -> list[ValidationFinding]:
+    return validate_branch_name(branch) + validate_pr_body(body)
+
+
+def render_failure_comment(findings: list[ValidationFinding]) -> str:
+    lines = [
+        VALIDATION_MARKER,
+        "## PR validation failed",
+        "",
+        "The PR still misses repository requirements. Fix the items below and push a new commit.",
+        "",
+    ]
+
+    for finding in findings:
+        lines.append(f"### {finding.section}")
+        lines.append(f"- Problem: {finding.problem}")
+        lines.append(f"- Fix: {finding.fix}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Required PR structure",
+            "",
+            "```md",
+            "## Linked Issue",
+            "- Closes #123",
+            "",
+            "## Milestone",
+            "- MS0",
+            "",
+            "## Summary",
+            "- What changed and why.",
+            "",
+            "## How to test",
+            "- Test type: automated | smoke | manual",
+            "- Steps: describe the commands or manual flow you ran.",
+            "",
+            "## Evidence",
+            "- Attach screenshots, logs, or manual checklist results when applicable.",
+            "",
+            "## Known risks",
+            "- List any known limitations or write `None` if there are none.",
+            "",
+            "## DoD checklist",
+            "- [ ] Scope implemented as defined",
+            "- [ ] Tests executed and documented",
+            "- [ ] Evidence attached",
+            "- [ ] No known critical breakage introduced",
+            "```",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def find_validation_comment(client: GitHubClient, repo: str, pr_number: int) -> dict | None:
+    for comment in client.list_issue_comments(repo, pr_number):
+        if VALIDATION_MARKER in (comment.get("body") or ""):
+            return comment
+    return None
+
+
+def upsert_validation_comment(client: GitHubClient, repo: str, pr_number: int, findings: list[ValidationFinding]) -> str | None:
+    existing = find_validation_comment(client, repo, pr_number)
+    if not findings:
+        if existing:
+            client.delete_issue_comment(repo, existing["id"])
+            return "deleted"
+        return None
+
+    body = render_failure_comment(findings)
+    if existing:
+        client.update_issue_comment(repo, existing["id"], body)
+        return "updated"
+    client.create_issue_comment(repo, pr_number, body)
+    return "created"

--- a/governance_bootstrap/project.py
+++ b/governance_bootstrap/project.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import json
+import re
+
+from .github import API_BASE, GitHubClient, split_repo
+
+
+def load_project_definition(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        definition = json.load(f)
+    if "name" not in definition:
+        raise ValueError("project definition must contain name")
+    return definition
+
+
+def owner_node(client: GitHubClient, owner: str) -> str:
+    query_user = "query($login:String!){user(login:$login){id}}"
+    data = client.graphql(query_user, {"login": owner})
+    user = data.get("user")
+    if user and user.get("id"):
+        return user["id"]
+    query_org = "query($login:String!){organization(login:$login){id}}"
+    data = client.graphql(query_org, {"login": owner})
+    org = data.get("organization")
+    if org and org.get("id"):
+        return org["id"]
+    raise RuntimeError(f"Owner not found: {owner}")
+
+
+def create_project(client: GitHubClient, repo: str, definition_file: str, dry_run: bool = False) -> None:
+    definition = load_project_definition(definition_file)
+    owner = split_repo(repo)[0]
+    if dry_run:
+        print(f"[DRY-RUN] Would create project: {definition['name']}")
+        print("[DRY-RUN] Fields to configure:")
+        for field in definition.get("fields", []):
+            print(f"- {field['name']} ({field['type']})")
+        return
+
+    oid = owner_node(client, owner)
+    mutation = """
+    mutation($owner:ID!, $title:String!) {
+      createProjectV2(input:{ownerId:$owner,title:$title}) {
+        projectV2 { id url }
+      }
+    }
+    """
+    data = client.graphql(mutation, {"owner": oid, "title": definition["name"]})
+    project = data["createProjectV2"]["projectV2"]
+    print(json.dumps(project, ensure_ascii=False))
+    print(f"Project created. Configure custom fields and views using {definition_file}.")
+
+
+def find_project(client: GitHubClient, owner: str, project_number: int) -> tuple[dict, str]:
+    query_user = """
+    query($login:String!, $number:Int!) {
+      user(login:$login) { projectV2(number:$number) { id title url } }
+    }
+    """
+    data = client.graphql(query_user, {"login": owner, "number": project_number})
+    user = data.get("user")
+    if user and user.get("projectV2"):
+        return user["projectV2"], "user"
+
+    query_org = """
+    query($login:String!, $number:Int!) {
+      organization(login:$login) { projectV2(number:$number) { id title url } }
+    }
+    """
+    data = client.graphql(query_org, {"login": owner, "number": project_number})
+    org = data.get("organization")
+    if org and org.get("projectV2"):
+        return org["projectV2"], "org"
+    raise RuntimeError(f"Project v2 #{project_number} not found for owner '{owner}'")
+
+
+def list_project_fields(client: GitHubClient, project_id: str) -> list[dict]:
+    query = """
+    query($project:ID!, $cursor:String) {
+      node(id:$project) {
+        ... on ProjectV2 {
+          fields(first:100, after:$cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              __typename
+              ... on ProjectV2Field { id name dataType }
+              ... on ProjectV2SingleSelectField { id name dataType options { id name } }
+              ... on ProjectV2IterationField { id name dataType }
+            }
+          }
+        }
+      }
+    }
+    """
+    fields = []
+    cursor = None
+    while True:
+        data = client.graphql(query, {"project": project_id, "cursor": cursor})
+        page = data["node"]["fields"]
+        fields.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            return fields
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def create_text_field(client: GitHubClient, project_id: str, name: str) -> dict:
+    mutation = """
+    mutation($project:ID!, $name:String!) {
+      createProjectV2Field(input:{projectId:$project, name:$name, dataType:TEXT}) {
+        projectV2Field { ... on ProjectV2Field { id name dataType } }
+      }
+    }
+    """
+    data = client.graphql(mutation, {"project": project_id, "name": name})
+    return data["createProjectV2Field"]["projectV2Field"]
+
+
+def create_single_select_field(client: GitHubClient, project_id: str, name: str, options: list[str]) -> dict:
+    mutation = """
+    mutation($project:ID!, $name:String!, $options:[ProjectV2SingleSelectFieldOptionInput!]!) {
+      createProjectV2Field(input:{projectId:$project, name:$name, dataType:SINGLE_SELECT, singleSelectOptions:$options}) {
+        projectV2Field { ... on ProjectV2SingleSelectField { id name dataType options { id name } } }
+      }
+    }
+    """
+    option_payload = [{"name": opt, "color": "GRAY", "description": ""} for opt in options]
+    data = client.graphql(mutation, {"project": project_id, "name": name, "options": option_payload})
+    return data["createProjectV2Field"]["projectV2Field"]
+
+
+def ensure_fields(client: GitHubClient, project_id: str, definition: dict, dry_run: bool = False) -> dict:
+    existing = list_project_fields(client, project_id)
+    by_name = {f["name"]: f for f in existing if f and f.get("name")}
+    for field in definition.get("fields", []):
+        name = field["name"]
+        if name in by_name:
+            continue
+        if dry_run:
+            print(f"[DRY-RUN] Would create field: {name} ({field['type']})")
+            continue
+        if field["type"] == "text":
+            created = create_text_field(client, project_id, name)
+        elif field["type"] == "single_select":
+            created = create_single_select_field(client, project_id, name, field.get("options", []))
+        else:
+            print(f"Skipping unsupported field type: {field['type']} ({name})")
+            continue
+        print(f"created field: {name}")
+        by_name[name] = created
+    if dry_run:
+        return by_name
+    return {f["name"]: f for f in list_project_fields(client, project_id) if f and f.get("name")}
+
+
+def list_repo_issues(client: GitHubClient, repo: str, state: str = "open") -> list[dict]:
+    owner, name = split_repo(repo)
+    issues = client.paginated(f"{API_BASE}/repos/{owner}/{name}/issues?state={state}&sort=created&direction=asc")
+    return [issue for issue in issues if "pull_request" not in issue]
+
+
+def list_project_items(client: GitHubClient, project_id: str) -> dict:
+    query = """
+    query($project:ID!, $cursor:String) {
+      node(id:$project) {
+        ... on ProjectV2 {
+          items(first:100, after:$cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              content { __typename ... on Issue { id number } }
+            }
+          }
+        }
+      }
+    }
+    """
+    content_to_item = {}
+    cursor = None
+    while True:
+        data = client.graphql(query, {"project": project_id, "cursor": cursor})
+        page = data["node"]["items"]
+        for item in page["nodes"]:
+            content = item.get("content")
+            if content and content.get("__typename") == "Issue":
+                content_to_item[content["id"]] = item["id"]
+        if not page["pageInfo"]["hasNextPage"]:
+            return content_to_item
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def issue_node_id(client: GitHubClient, repo: str, number: int) -> str:
+    owner, name = split_repo(repo)
+    query = """
+    query($owner:String!, $repo:String!, $number:Int!) {
+      repository(owner:$owner, name:$repo) { issue(number:$number) { id } }
+    }
+    """
+    data = client.graphql(query, {"owner": owner, "repo": name, "number": number})
+    issue = data["repository"]["issue"]
+    if not issue:
+        raise RuntimeError(f"Issue #{number} not found in {repo}")
+    return issue["id"]
+
+
+def add_issue_to_project(client: GitHubClient, project_id: str, issue_id: str) -> str:
+    mutation = """
+    mutation($project:ID!, $content:ID!) {
+      addProjectV2ItemById(input:{projectId:$project, contentId:$content}) { item { id } }
+    }
+    """
+    data = client.graphql(mutation, {"project": project_id, "content": issue_id})
+    return data["addProjectV2ItemById"]["item"]["id"]
+
+
+def add_sub_issue(client: GitHubClient, parent_id: str, child_id: str) -> None:
+    mutation = """
+    mutation($parent:ID!, $child:ID!) {
+      addSubIssue(input:{issueId:$parent, subIssueId:$child}) { clientMutationId }
+    }
+    """
+    client.graphql(mutation, {"parent": parent_id, "child": child_id})
+
+
+def update_item_position(client: GitHubClient, project_id: str, item_id: str, after_id: str | None) -> None:
+    mutation = """
+    mutation($project:ID!, $item:ID!, $after:ID) {
+      updateProjectV2ItemPosition(input:{projectId:$project, itemId:$item, afterId:$after}) { clientMutationId }
+    }
+    """
+    client.graphql(mutation, {"project": project_id, "item": item_id, "after": after_id})
+
+
+def update_single_select(client: GitHubClient, project_id: str, item_id: str, field_id: str, option_id: str) -> None:
+    mutation = """
+    mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) {
+      updateProjectV2ItemFieldValue(input:{projectId:$project, itemId:$item, fieldId:$field, value:{singleSelectOptionId:$option}}) {
+        projectV2Item { id }
+      }
+    }
+    """
+    client.graphql(mutation, {"project": project_id, "item": item_id, "field": field_id, "option": option_id})
+
+
+def update_text(client: GitHubClient, project_id: str, item_id: str, field_id: str, text_value: str) -> None:
+    mutation = """
+    mutation($project:ID!, $item:ID!, $field:ID!, $text:String!) {
+      updateProjectV2ItemFieldValue(input:{projectId:$project, itemId:$item, fieldId:$field, value:{text:$text}}) {
+        projectV2Item { id }
+      }
+    }
+    """
+    client.graphql(mutation, {"project": project_id, "item": item_id, "field": field_id, "text": text_value})
+
+
+def milestone_from_body(body: str) -> str | None:
+    match = re.search(r"-\s*Milestone:\s*([A-Za-z0-9_.-]+)", body or "")
+    return match.group(1) if match else None
+
+
+def milestone_from_issue(issue: dict) -> str | None:
+    milestone = issue.get("milestone")
+    if milestone and milestone.get("title"):
+        return milestone["title"]
+    return milestone_from_body(issue.get("body", "") or "")
+
+
+def parent_issue_number_from_body(body: str) -> int | None:
+    match = re.search(r"Parent story:.*\(#(\d+)\)", body or "")
+    return int(match.group(1)) if match else None
+
+
+def label_value(labels: list, prefix: str) -> str | None:
+    for label in labels:
+        name = label["name"] if isinstance(label, dict) else str(label)
+        if name.startswith(prefix):
+            return name.split(":", 1)[1]
+    return None
+
+
+def option_id(field: dict, option_name: str) -> str | None:
+    for opt in field.get("options", []):
+        if opt["name"] == option_name:
+            return opt["id"]
+    return None
+
+
+def sync_issue_fields(client: GitHubClient, project_id: str, item_id: str, issue: dict, fields: dict, definition: dict, dry_run: bool = False) -> None:
+    labels = issue.get("labels", [])
+    milestone = milestone_from_issue(issue)
+    phase_map = definition.get("phaseMilestoneMap", {})
+    mappings = {
+        "Phase": phase_map.get(milestone),
+        "Item Type": label_value(labels, "type:"),
+        "Priority": label_value(labels, "priority:"),
+        "Status": label_value(labels, "status:"),
+        "Test Type": label_value(labels, "test:"),
+        "Milestone": milestone,
+    }
+
+    for field_name, field_value in mappings.items():
+        if not field_value:
+            continue
+        field = fields.get(field_name)
+        if not field:
+            continue
+        if field.get("dataType") == "SINGLE_SELECT":
+            oid = option_id(field, field_value)
+            if not oid:
+                print(f"warning: option '{field_value}' not found for field '{field_name}'")
+                continue
+            if dry_run:
+                print(f"[DRY-RUN] Would set {field_name}={field_value} on issue #{issue['number']}")
+            else:
+                update_single_select(client, project_id, item_id, field["id"], oid)
+        elif field.get("dataType") == "TEXT":
+            if dry_run:
+                print(f"[DRY-RUN] Would set {field_name}={field_value} on issue #{issue['number']}")
+            else:
+                update_text(client, project_id, item_id, field["id"], field_value)
+
+
+def reorder_project_items(client: GitHubClient, project_id: str, issues: list[dict], current_items: dict, dry_run: bool = False) -> None:
+    previous_item_id = None
+    for issue in issues:
+        item_id = current_items.get(issue["node_id"])
+        if not item_id:
+            continue
+        if dry_run:
+            print(f"[DRY-RUN] Would position issue #{issue['number']} after {previous_item_id or 'top'}")
+        else:
+            update_item_position(client, project_id, item_id, previous_item_id)
+        previous_item_id = item_id
+
+
+def link_subissues(client: GitHubClient, repo: str, issues: list[dict], dry_run: bool = False) -> None:
+    node_ids_by_number = {issue["number"]: issue.get("node_id") for issue in issues}
+    linked = 0
+    skipped = 0
+
+    for issue in issues:
+        parent_number = parent_issue_number_from_body(issue.get("body", "") or "")
+        if parent_number is None:
+            continue
+
+        parent_id = node_ids_by_number.get(parent_number)
+        if not parent_id:
+            parent_id = issue_node_id(client, repo, parent_number)
+            node_ids_by_number[parent_number] = parent_id
+
+        if dry_run:
+            print(f"[DRY-RUN] Would link issue #{issue['number']} as sub-issue of #{parent_number}")
+            continue
+
+        try:
+            add_sub_issue(client, parent_id, issue["node_id"])
+            print(f"Linked issue #{issue['number']} as sub-issue of #{parent_number}")
+            linked += 1
+        except RuntimeError as exc:
+            error_text = str(exc).lower()
+            if (
+                "already" in error_text
+                or "exists" in error_text
+                or "duplicate sub-issues" in error_text
+                or "may only have one parent" in error_text
+            ):
+                print(f"Sub-issue link already exists: #{issue['number']} -> #{parent_number}")
+                skipped += 1
+                continue
+            raise
+
+    print(f"Sub-issue linking finished: linked={linked}, already_present={skipped}")
+
+
+def sync_project(client: GitHubClient, repo: str, definition_file: str, project_number: int, owner: str | None = None, issue_state: str = "open", link_subissue_items: bool = False, only_link_subissues: bool = False, dry_run: bool = False) -> None:
+    definition = load_project_definition(definition_file)
+    project_owner = owner or split_repo(repo)[0]
+    issues = list_repo_issues(client, repo, state=issue_state)
+    for issue in issues:
+        issue["node_id"] = issue_node_id(client, repo, issue["number"])
+
+    if only_link_subissues:
+        link_subissues(client, repo, issues, dry_run=dry_run)
+        return
+
+    project, owner_type = find_project(client, project_owner, project_number)
+    print(f"Project found: {project['title']} ({project['url']}) owner_type={owner_type}")
+    fields = ensure_fields(client, project["id"], definition, dry_run=dry_run)
+    current_items = list_project_items(client, project["id"])
+
+    for issue in issues:
+        issue_id = issue["node_id"]
+        item_id = current_items.get(issue_id)
+        if not item_id:
+            if dry_run:
+                print(f"[DRY-RUN] Would add issue #{issue['number']} to project")
+                item_id = f"dry-run-item-{issue['number']}"
+            else:
+                item_id = add_issue_to_project(client, project["id"], issue_id)
+                current_items[issue_id] = item_id
+                print(f"Added issue #{issue['number']} to project")
+        else:
+            print(f"Issue #{issue['number']} already in project")
+        sync_issue_fields(client, project["id"], item_id, issue, fields, definition, dry_run=dry_run)
+
+    reorder_project_items(client, project["id"], issues, current_items, dry_run=dry_run)
+    if link_subissue_items:
+        link_subissues(client, repo, issues, dry_run=dry_run)
+    if definition.get("views"):
+        print("Note: project views are listed in project-definition.json but are not automated by this script.")
+        for view in definition["views"]:
+            print(f"- create manually if needed: {view}")

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,10 @@ config/name="Take Your Pills"
 run/main_scene="res://scenes/game/game.tscn"
 config/features=PackedStringArray("4.6")
 
+[autoload]
+
+RunSignals="*res://scripts/run_signals.gd"
+
 [rendering]
 
 renderer/rendering_method.mobile="forward_plus"

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,10 @@ config/features=PackedStringArray("4.6")
 
 RunSignals="*res://scripts/run_signals.gd"
 
+[display]
+
+window/stretch/mode="canvas_items"
+
 [rendering]
 
 renderer/rendering_method.mobile="forward_plus"

--- a/scenes/game/chunk_manager.gd
+++ b/scenes/game/chunk_manager.gd
@@ -1,0 +1,123 @@
+extends Node2D
+class_name ChunkManager
+
+const CHUNK_SCENES: Array[PackedScene] = [
+	preload("res://scenes/game/chunks/chunk_a.tscn"),
+	preload("res://scenes/game/chunks/chunk_b.tscn"),
+	preload("res://scenes/game/chunks/chunk_c.tscn"),
+]
+
+@export var scroll_speed: float = 240.0
+@export var chunk_width: float = 640.0
+@export var initial_chunk_count: int = 3
+
+var scrolling_enabled: bool = false
+var _active_chunks: Array[Node2D] = []
+var _spawn_cursor: int = 0
+
+
+func _ready() -> void:
+	RunSignals.request_next_chunk.connect(_on_request_next_chunk)
+	RunSignals.chunk_exited_screen.connect(_on_chunk_exited_screen)
+	reset_run()
+
+
+func start_run() -> void:
+	scrolling_enabled = true
+
+
+func pause_run() -> void:
+	scrolling_enabled = false
+
+
+func end_run() -> void:
+	scrolling_enabled = false
+
+
+func reset_run() -> void:
+	scrolling_enabled = false
+	_spawn_cursor = 0
+	_clear_chunks()
+	for index in range(initial_chunk_count):
+		_spawn_chunk(Vector2(chunk_width * index, 0.0))
+
+
+func set_scroll_speed(value: float) -> void:
+	scroll_speed = maxf(value, 0.0)
+
+
+func _physics_process(delta: float) -> void:
+	if not scrolling_enabled:
+		return
+
+	var displacement := scroll_speed * delta
+	for chunk in _active_chunks:
+		chunk.position.x -= displacement
+
+
+func _on_request_next_chunk(chunk: Node) -> void:
+	if not scrolling_enabled:
+		return
+
+	if _active_chunks.is_empty():
+		return
+
+	var tail_chunk := _get_tail_chunk()
+	if chunk != tail_chunk:
+		return
+
+	_spawn_chunk(Vector2(_get_rightmost_x() + chunk_width, 0.0))
+
+
+func _on_chunk_exited_screen(chunk: Node) -> void:
+	var typed_chunk := chunk as Node2D
+	if typed_chunk == null:
+		return
+
+	if _active_chunks.has(typed_chunk):
+		_active_chunks.erase(typed_chunk)
+		typed_chunk.queue_free()
+
+
+func _spawn_chunk(position: Vector2) -> void:
+	if CHUNK_SCENES.is_empty():
+		return
+
+	var scene_index := _spawn_cursor % CHUNK_SCENES.size()
+	var chunk := CHUNK_SCENES[scene_index].instantiate() as Node2D
+	_spawn_cursor += 1
+	chunk.position = position
+	add_child(chunk)
+	_active_chunks.append(chunk)
+
+
+func _clear_chunks() -> void:
+	for chunk in _active_chunks:
+		if is_instance_valid(chunk):
+			chunk.queue_free()
+
+	_active_chunks.clear()
+
+
+func _get_tail_chunk() -> Node2D:
+	if _active_chunks.is_empty():
+		return null
+
+	var tail_chunk := _active_chunks[0]
+	for chunk in _active_chunks:
+		if chunk.position.x > tail_chunk.position.x:
+			tail_chunk = chunk
+
+	return tail_chunk
+
+
+func _get_rightmost_x() -> float:
+	if _active_chunks.is_empty():
+		return 0.0
+
+	var rightmost_x := _active_chunks[0].position.x
+	for chunk in _active_chunks:
+		if chunk.position.x > rightmost_x:
+			rightmost_x = chunk.position.x
+
+	return rightmost_x

--- a/scenes/game/chunk_manager.gd.uid
+++ b/scenes/game/chunk_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://iw5oeajdsc1c

--- a/scenes/game/chunks/chunk.gd
+++ b/scenes/game/chunks/chunk.gd
@@ -1,0 +1,25 @@
+extends Node2D
+class_name Chunk
+
+@onready var trigger_next: Area2D = $TriggerNext
+@onready var on_screen_notifier: VisibleOnScreenNotifier2D = $OnScreenNotifier
+
+var _requested_next_chunk: bool = false
+
+
+func _ready() -> void:
+	trigger_next.body_entered.connect(_on_trigger_next_body_entered)
+	on_screen_notifier.screen_exited.connect(_on_screen_exited)
+
+
+func _on_trigger_next_body_entered(body: Node) -> void:
+	if _requested_next_chunk:
+		return
+
+	if body is Player:
+		_requested_next_chunk = true
+		RunSignals.request_next_chunk.emit(self)
+
+
+func _on_screen_exited() -> void:
+	RunSignals.chunk_exited_screen.emit(self)

--- a/scenes/game/chunks/chunk.gd.uid
+++ b/scenes/game/chunks/chunk.gd.uid
@@ -1,0 +1,1 @@
+uid://c4x3k1a52yh6p

--- a/scenes/game/chunks/chunk_a.tscn
+++ b/scenes/game/chunks/chunk_a.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scenes/game/chunks/chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(640, 96)
+
+[sub_resource type="RectangleShape2D" id="2"]
+size = Vector2(24, 320)
+
+[node name="ChunkA" type="Node2D"]
+script = ExtResource("1")
+
+[node name="TileMapLayer" type="TileMapLayer" parent="."]
+
+[node name="Terrain" type="Node2D" parent="."]
+
+[node name="Sky" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 0, 640, 0, 640, 360, 0, 360)
+color = Color(0.05, 0.07, 0.13, 1)
+
+[node name="TowerLeft" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(72, 200, 144, 200, 144, 264, 72, 264)
+color = Color(0.14, 0.16, 0.23, 1)
+
+[node name="TowerRight" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(260, 168, 356, 168, 356, 264, 260, 264)
+color = Color(0.10, 0.12, 0.18, 1)
+
+[node name="GroundVisual" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 264, 640, 264, 640, 360, 0, 360)
+color = Color(0.13, 0.13, 0.15, 1)
+
+[node name="LaneStripe" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 252, 640, 252, 640, 256, 0, 256)
+color = Color(0.86, 0.78, 0.31, 1)
+
+[node name="GroundBody" type="StaticBody2D" parent="Terrain"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Terrain/GroundBody"]
+position = Vector2(320, 312)
+shape = SubResource("1")
+
+[node name="TriggerNext" type="Area2D" parent="."]
+position = Vector2(576, 240)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TriggerNext"]
+shape = SubResource("2")
+
+[node name="OnScreenNotifier" type="VisibleOnScreenNotifier2D" parent="."]
+rect = Rect2(0, 0, 640, 360)

--- a/scenes/game/chunks/chunk_b.tscn
+++ b/scenes/game/chunks/chunk_b.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scenes/game/chunks/chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(640, 96)
+
+[sub_resource type="RectangleShape2D" id="2"]
+size = Vector2(24, 320)
+
+[node name="ChunkB" type="Node2D"]
+script = ExtResource("1")
+
+[node name="TileMapLayer" type="TileMapLayer" parent="."]
+
+[node name="Terrain" type="Node2D" parent="."]
+
+[node name="Sky" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 0, 640, 0, 640, 360, 0, 360)
+color = Color(0.06, 0.08, 0.15, 1)
+
+[node name="TowerLeft" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(96, 192, 176, 192, 176, 264, 96, 264)
+color = Color(0.16, 0.18, 0.25, 1)
+
+[node name="TowerRight" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(328, 160, 424, 160, 424, 264, 328, 264)
+color = Color(0.11, 0.13, 0.19, 1)
+
+[node name="GroundVisual" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 264, 640, 264, 640, 360, 0, 360)
+color = Color(0.12, 0.12, 0.14, 1)
+
+[node name="LaneStripe" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 252, 640, 252, 640, 256, 0, 256)
+color = Color(0.86, 0.78, 0.31, 1)
+
+[node name="GroundBody" type="StaticBody2D" parent="Terrain"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Terrain/GroundBody"]
+position = Vector2(320, 312)
+shape = SubResource("1")
+
+[node name="TriggerNext" type="Area2D" parent="."]
+position = Vector2(576, 240)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TriggerNext"]
+shape = SubResource("2")
+
+[node name="OnScreenNotifier" type="VisibleOnScreenNotifier2D" parent="."]
+rect = Rect2(0, 0, 640, 360)

--- a/scenes/game/chunks/chunk_c.tscn
+++ b/scenes/game/chunks/chunk_c.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scenes/game/chunks/chunk.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(640, 96)
+
+[sub_resource type="RectangleShape2D" id="2"]
+size = Vector2(24, 320)
+
+[node name="ChunkC" type="Node2D"]
+script = ExtResource("1")
+
+[node name="TileMapLayer" type="TileMapLayer" parent="."]
+
+[node name="Terrain" type="Node2D" parent="."]
+
+[node name="Sky" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 0, 640, 0, 640, 360, 0, 360)
+color = Color(0.05, 0.06, 0.12, 1)
+
+[node name="TowerLeft" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(48, 184, 112, 184, 112, 264, 48, 264)
+color = Color(0.15, 0.17, 0.22, 1)
+
+[node name="TowerRight" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(256, 200, 352, 200, 352, 264, 256, 264)
+color = Color(0.10, 0.11, 0.17, 1)
+
+[node name="GroundVisual" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 264, 640, 264, 640, 360, 0, 360)
+color = Color(0.14, 0.14, 0.16, 1)
+
+[node name="LaneStripe" type="Polygon2D" parent="Terrain"]
+polygon = PackedVector2Array(0, 252, 640, 252, 640, 256, 0, 256)
+color = Color(0.86, 0.78, 0.31, 1)
+
+[node name="GroundBody" type="StaticBody2D" parent="Terrain"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Terrain/GroundBody"]
+position = Vector2(320, 312)
+shape = SubResource("1")
+
+[node name="TriggerNext" type="Area2D" parent="."]
+position = Vector2(576, 240)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TriggerNext"]
+shape = SubResource("2")
+
+[node name="OnScreenNotifier" type="VisibleOnScreenNotifier2D" parent="."]
+rect = Rect2(0, 0, 640, 360)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1,21 +1,24 @@
 extends Node2D
 class_name Game
 
-const DEFAULT_RUN_SPEED := 240.0
+const DEFAULT_SCROLL_SPEED := 240.0
 
 enum GameState { RUNNING, PAUSED, GAME_OVER }
 
-@onready var player: Player = $Player
+@onready var player: Player = $World/Player
+@onready var chunks = $World/Chunks
 @onready var state_label: Label = $HUD/StateLabel
 @onready var restart_button: Button = $HUD/RestartButton
 
 var current_state: GameState = GameState.RUNNING
+var transient_note: String = ""
 
 
 func _ready() -> void:
 	_ensure_input_actions()
 	restart_button.pressed.connect(_on_restart_button_pressed)
-	player.set_run_speed(DEFAULT_RUN_SPEED)
+	chunks.set_scroll_speed(DEFAULT_SCROLL_SPEED)
+	chunks.start_run()
 	player.start_run()
 	player.primary_action_requested.connect(_on_player_primary_action_requested)
 	_update_state_label()
@@ -43,29 +46,36 @@ func _toggle_pause() -> void:
 
 	if current_state == GameState.RUNNING:
 		current_state = GameState.PAUSED
+		chunks.pause_run()
 		player.pause_run()
 	else:
 		current_state = GameState.RUNNING
+		chunks.start_run()
 		player.start_run()
 
 	_update_state_label()
 
 
 func _set_game_over() -> void:
+	if current_state == GameState.GAME_OVER:
+		return
+
 	current_state = GameState.GAME_OVER
+	chunks.end_run()
 	player.end_run()
 	_update_state_label()
 
 
 func _on_player_primary_action_requested() -> void:
-	_update_state_label("Primary action accepted")
+	transient_note = "Primary action accepted"
+	_update_state_label()
 
 
 func _on_restart_button_pressed() -> void:
 	get_tree().reload_current_scene()
 
 
-func _update_state_label(extra_note: String = "") -> void:
+func _update_state_label() -> void:
 	var state_text := "RUNNING"
 	if current_state == GameState.PAUSED:
 		state_text = "PAUSED"
@@ -73,10 +83,12 @@ func _update_state_label(extra_note: String = "") -> void:
 		state_text = "GAME OVER"
 
 	var control_note := "Space: primary | Esc: pause | Backspace: game over"
-	if extra_note.is_empty():
+
+	if transient_note.is_empty():
 		state_label.text = "%s\n%s\nRestart: button" % [state_text, control_note]
 	else:
-		state_label.text = "%s\n%s\n%s\nRestart: button" % [state_text, extra_note, control_note]
+		state_label.text = "%s\n%s\n%s\nRestart: button" % [state_text, transient_note, control_note]
+		transient_note = ""
 
 
 func _ensure_input_actions() -> void:

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -2,6 +2,8 @@ extends Node2D
 class_name Game
 
 const DEFAULT_SCROLL_SPEED := 240.0
+const SCORE_DISTANCE_DIVISOR := 10.0
+const NOTE_DISPLAY_DURATION := 2.0
 
 enum GameState { RUNNING, PAUSED, GAME_OVER }
 
@@ -26,7 +28,7 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
 	if current_state == GameState.RUNNING:
-		var new_score = int(player.position.x / 10.0)
+		var new_score = int(player.position.x / SCORE_DISTANCE_DIVISOR)
 		if new_score != score:
 			score = new_score
 			_update_hud()
@@ -84,7 +86,7 @@ func _set_game_over() -> void:
 func _on_player_primary_action_requested() -> void:
 	active_note = "Primary action accepted"
 	_update_hud()
-	await get_tree().create_timer(2.0).timeout
+	await get_tree().create_timer(NOTE_DISPLAY_DURATION).timeout
 	if active_note == "Primary action accepted":
 		active_note = ""
 		_update_hud()

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -15,110 +15,110 @@ var active_note: String = ""
 
 
 func _ready() -> void:
-_ensure_input_actions()
-hud.connect_restart(_on_restart_button_pressed)
-chunks.set_scroll_speed(DEFAULT_SCROLL_SPEED)
-chunks.start_run()
-player.start_run()
-player.primary_action_requested.connect(_on_player_primary_action_requested)
-_update_hud()
+	_ensure_input_actions()
+	hud.connect_restart(_on_restart_button_pressed)
+	chunks.set_scroll_speed(DEFAULT_SCROLL_SPEED)
+	chunks.start_run()
+	player.start_run()
+	player.primary_action_requested.connect(_on_player_primary_action_requested)
+	_update_hud()
 
 
 func _process(_delta: float) -> void:
-if current_state == GameState.RUNNING:
-var new_score = int(player.position.x / 10.0)
-if new_score != score:
-score = new_score
-_update_hud()
+	if current_state == GameState.RUNNING:
+		var new_score = int(player.position.x / 10.0)
+		if new_score != score:
+			score = new_score
+			_update_hud()
 
 
 func _unhandled_input(event: InputEvent) -> void:
-if event.is_action_pressed("game_pause"):
-_toggle_pause()
-get_viewport().set_input_as_handled()
-return
+	if event.is_action_pressed("game_pause"):
+		_toggle_pause()
+		get_viewport().set_input_as_handled()
+		return
 
-if event.is_action_pressed("game_over_debug"):
-_set_game_over()
-get_viewport().set_input_as_handled()
-return
+	if event.is_action_pressed("game_over_debug"):
+		_set_game_over()
+		get_viewport().set_input_as_handled()
+		return
 
-if event.is_action_pressed(player.primary_action_name):
-player.request_primary_action()
-get_viewport().set_input_as_handled()
-return
+	if event.is_action_pressed(player.primary_action_name):
+		player.request_primary_action()
+		get_viewport().set_input_as_handled()
+		return
 
-if event.is_action_pressed(player.jump_action_name):
-player.request_jump()
-get_viewport().set_input_as_handled()
-return
+	if event.is_action_pressed(player.jump_action_name):
+		player.request_jump()
+		get_viewport().set_input_as_handled()
+		return
 
 
 func _toggle_pause() -> void:
-if current_state == GameState.GAME_OVER:
-return
+	if current_state == GameState.GAME_OVER:
+		return
 
-if current_state == GameState.RUNNING:
-current_state = GameState.PAUSED
-chunks.pause_run()
-player.pause_run()
-else:
-current_state = GameState.RUNNING
-chunks.start_run()
-player.start_run()
+	if current_state == GameState.RUNNING:
+		current_state = GameState.PAUSED
+		chunks.pause_run()
+		player.pause_run()
+	else:
+		current_state = GameState.RUNNING
+		chunks.start_run()
+		player.start_run()
 
-_update_hud()
+	_update_hud()
 
 
 func _set_game_over() -> void:
-if current_state == GameState.GAME_OVER:
-return
+	if current_state == GameState.GAME_OVER:
+		return
 
-current_state = GameState.GAME_OVER
-chunks.end_run()
-player.end_run()
-hud.show_game_over()
-_update_hud()
+	current_state = GameState.GAME_OVER
+	chunks.end_run()
+	player.end_run()
+	hud.show_game_over()
+	_update_hud()
 
 
 func _on_player_primary_action_requested() -> void:
-active_note = "Primary action accepted"
-_update_hud()
-await get_tree().create_timer(2.0).timeout
-if active_note == "Primary action accepted":
-active_note = ""
-_update_hud()
+	active_note = "Primary action accepted"
+	_update_hud()
+	await get_tree().create_timer(2.0).timeout
+	if active_note == "Primary action accepted":
+		active_note = ""
+		_update_hud()
 
 
 func _on_restart_button_pressed() -> void:
-get_tree().reload_current_scene()
+	get_tree().reload_current_scene()
 
 
 func _update_hud() -> void:
-var state_text := "RUNNING"
-if current_state == GameState.PAUSED:
-state_text = "PAUSED"
-elif current_state == GameState.GAME_OVER:
-state_text = "GAME OVER"
+	var state_text := "RUNNING"
+	if current_state == GameState.PAUSED:
+		state_text = "PAUSED"
+	elif current_state == GameState.GAME_OVER:
+		state_text = "GAME OVER"
 
-var control_note := "Space: primary | Up: jump | Esc: pause | Backspace: game over"
-hud.update_state(state_text, control_note, active_note)
-hud.update_score(score)
+	var control_note := "Space: primary | Up: jump | Esc: pause | Backspace: game over"
+	hud.update_state(state_text, control_note, active_note)
+	hud.update_score(score)
 
 
 func _ensure_input_actions() -> void:
-_register_key_action(player.primary_action_name, KEY_SPACE)
-_register_key_action(player.jump_action_name, KEY_UP)
-_register_key_action("game_pause", KEY_ESCAPE)
-_register_key_action("game_over_debug", KEY_BACKSPACE)
+	_register_key_action(player.primary_action_name, KEY_SPACE)
+	_register_key_action(player.jump_action_name, KEY_UP)
+	_register_key_action("game_pause", KEY_ESCAPE)
+	_register_key_action("game_over_debug", KEY_BACKSPACE)
 
 
 func _register_key_action(action_name: StringName, keycode: Key) -> void:
-if not InputMap.has_action(action_name):
-InputMap.add_action(action_name)
+	if not InputMap.has_action(action_name):
+		InputMap.add_action(action_name)
 
-InputMap.action_erase_events(action_name)
+	InputMap.action_erase_events(action_name)
 
-var event := InputEventKey.new()
-event.keycode = keycode
-InputMap.action_add_event(action_name, event)
+	var event := InputEventKey.new()
+	event.keycode = keycode
+	InputMap.action_add_event(action_name, event)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -88,7 +88,12 @@ func _update_state_label() -> void:
 	elif current_state == GameState.GAME_OVER:
 		state_text = "GAME OVER"
 
-	var control_note := "Space: primary | Up: jump | Esc: pause | Backspace: game over"
+	var primary_hint := _action_hint(player.primary_action_name, "Space")
+	var jump_hint := _action_hint(player.jump_action_name, "Up")
+	var control_note := "%s: primary | %s: jump | Esc: pause | Backspace: game over" % [
+		primary_hint,
+		jump_hint,
+	]
 
 	if transient_note.is_empty():
 		state_label.text = "%s\n%s\nRestart: button" % [state_text, control_note]
@@ -113,3 +118,16 @@ func _register_key_action(action_name: StringName, keycode: Key) -> void:
 	var event := InputEventKey.new()
 	event.keycode = keycode
 	InputMap.action_add_event(action_name, event)
+
+
+func _action_hint(action_name: StringName, fallback: String) -> String:
+	for event in InputMap.action_get_events(action_name):
+		var key_event := event as InputEventKey
+		if key_event == null:
+			continue
+
+		var key_label := key_event.as_text_keycode()
+		if not key_label.is_empty():
+			return key_label
+
+	return fallback

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -6,7 +6,7 @@ const DEFAULT_SCROLL_SPEED := 240.0
 enum GameState { RUNNING, PAUSED, GAME_OVER }
 
 @onready var player: Player = $World/Player
-@onready var chunks = $World/Chunks
+@onready var chunks: ChunkManager = $World/Chunks
 @onready var state_label: Label = $HUD/StateLabel
 @onready var restart_button: Button = $HUD/RestartButton
 
@@ -38,6 +38,12 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(player.primary_action_name):
 		player.request_primary_action()
 		get_viewport().set_input_as_handled()
+		return
+
+	if event.is_action_pressed(player.jump_action_name):
+		player.request_jump()
+		get_viewport().set_input_as_handled()
+		return
 
 
 func _toggle_pause() -> void:
@@ -82,7 +88,7 @@ func _update_state_label() -> void:
 	elif current_state == GameState.GAME_OVER:
 		state_text = "GAME OVER"
 
-	var control_note := "Space: primary | Esc: pause | Backspace: game over"
+	var control_note := "Space: primary | Up: jump | Esc: pause | Backspace: game over"
 
 	if transient_note.is_empty():
 		state_label.text = "%s\n%s\nRestart: button" % [state_text, control_note]
@@ -93,6 +99,7 @@ func _update_state_label() -> void:
 
 func _ensure_input_actions() -> void:
 	_register_key_action(player.primary_action_name, KEY_SPACE)
+	_register_key_action(player.jump_action_name, KEY_UP)
 	_register_key_action("game_pause", KEY_ESCAPE)
 	_register_key_action("game_over_debug", KEY_BACKSPACE)
 

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -1,13 +1,19 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scenes/game/game.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/player/player.tscn" id="2"]
+[ext_resource type="Script" path="res://scenes/game/chunk_manager.gd" id="3"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
 
-[node name="Player" parent="." instance=ExtResource("2")]
+[node name="World" type="Node2D" parent="."]
+
+[node name="Player" parent="World" instance=ExtResource("2")]
 position = Vector2(160, 240)
+
+[node name="Chunks" type="Node2D" parent="World"]
+script = ExtResource("3")
 
 [node name="HUD" type="CanvasLayer" parent="."]
 

--- a/scenes/game/hud.tscn
+++ b/scenes/game/hud.tscn
@@ -28,8 +28,7 @@ text = "Score: 000000"
 [node name="StateLabel" type="Label" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 18
-text = "State: RUNNING
-Controls: Space to jump"
+text = "State: RUNNING\nControls: Space to jump"
 
 [node name="RestartButton" type="Button" parent="MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(150, 50)

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -1,7 +1,6 @@
 extends CharacterBody2D
 class_name Player
 
-@export var base_run_speed: float = 240.0
 @export var primary_action_name: StringName = &"player_primary"
 
 enum RunState { RUNNING, PAUSED, DEAD }
@@ -9,11 +8,6 @@ enum RunState { RUNNING, PAUSED, DEAD }
 signal primary_action_requested
 
 var current_state: RunState = RunState.PAUSED
-var run_speed: float = 240.0
-
-
-func _ready() -> void:
-	run_speed = base_run_speed
 
 
 func start_run() -> void:
@@ -38,14 +32,6 @@ func request_primary_action() -> bool:
 	return true
 
 
-func set_run_speed(value: float) -> void:
-	run_speed = maxf(value, 0.0)
-
-
 func _physics_process(_delta: float) -> void:
-	if current_state == RunState.RUNNING:
-		velocity.x = run_speed
-	else:
-		velocity.x = 0.0
-
+	velocity.x = 0.0
 	move_and_slide()

--- a/scenes/player/player.gd
+++ b/scenes/player/player.gd
@@ -2,12 +2,23 @@ extends CharacterBody2D
 class_name Player
 
 @export var primary_action_name: StringName = &"player_primary"
+@export var jump_action_name: StringName = &"player_jump"
+@export var jump_velocity: float = -420.0
+@export var gravity: float = 1200.0
+@export var max_fall_speed: float = 1200.0
+@export var ground_snap_length: float = 8.0
 
 enum RunState { RUNNING, PAUSED, DEAD }
 
 signal primary_action_requested
 
 var current_state: RunState = RunState.PAUSED
+var _jump_requested: bool = false
+var _grounded: bool = true
+
+
+func _ready() -> void:
+	floor_snap_length = ground_snap_length
 
 
 func start_run() -> void:
@@ -17,11 +28,13 @@ func start_run() -> void:
 func pause_run() -> void:
 	current_state = RunState.PAUSED
 	velocity.x = 0.0
+	_jump_requested = false
 
 
 func end_run() -> void:
 	current_state = RunState.DEAD
 	velocity.x = 0.0
+	_jump_requested = false
 
 
 func request_primary_action() -> bool:
@@ -32,6 +45,32 @@ func request_primary_action() -> bool:
 	return true
 
 
+func request_jump() -> bool:
+	if current_state != RunState.RUNNING:
+		return false
+
+	_jump_requested = true
+	return true
+
+
 func _physics_process(_delta: float) -> void:
+	if current_state != RunState.RUNNING:
+		return
+
 	velocity.x = 0.0
+
+	if _jump_requested and _grounded:
+		velocity.y = jump_velocity
+		_grounded = false
+	elif not _grounded:
+		velocity.y = minf(velocity.y + (gravity * _delta), max_fall_speed)
+	elif velocity.y > 0.0:
+		velocity.y = 0.0
+
 	move_and_slide()
+
+	_grounded = is_on_floor()
+	if _grounded and velocity.y > 0.0:
+		velocity.y = 0.0
+
+	_jump_requested = false

--- a/scenes/player/player.tscn
+++ b/scenes/player/player.tscn
@@ -7,6 +7,7 @@ size = Vector2(24, 48)
 
 [node name="Player" type="CharacterBody2D"]
 script = ExtResource("1")
+z_index = 10
 
 [node name="Visual" type="Polygon2D" parent="."]
 polygon = PackedVector2Array(-12, -24, 12, -24, 12, 24, -12, 24)

--- a/scripts/github/auto_label/apply.py
+++ b/scripts/github/auto_label/apply.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Apply repository labels inferred from issue or PR metadata")
+    parser.add_argument("--event-path")
+    parser.add_argument("--labels-file", default="config/project/labels.json")
+    parser.add_argument("--repo")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["auto-label", "apply", "--labels-file", args.labels_file]
+    if args.event_path:
+        cli_args += ["--event-path", args.event_path]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/bootstrap/local.sh
+++ b/scripts/github/bootstrap/local.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+exec "${ROOT_DIR}/scripts/github/bootstrap_local.sh" "$@"

--- a/scripts/github/issue_milestones/sync.py
+++ b/scripts/github/issue_milestones/sync.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Sync repository issue milestones from generated issue metadata")
+    parser.add_argument("--repo")
+    parser.add_argument("--clear-not-planned", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["issue-milestones", "sync"]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.clear_not_planned:
+        cli_args += ["--clear-not-planned"]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/issues/create.sh
+++ b/scripts/github/issues/create.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+TITLE="${TITLE:-}"
+BODY="${BODY:-}"
+BODY_FILE="${BODY_FILE:-}"
+LABELS="${LABELS:-}"
+
+if [[ -z "${REPO}" ]]; then
+  echo "Missing repository. Set REPO or GITHUB_REPOSITORY."
+  exit 1
+fi
+
+if [[ -z "${TITLE}" ]]; then
+  echo "Missing TITLE."
+  exit 1
+fi
+
+cmd=(gh issue create --repo "${REPO}" --title "${TITLE}")
+if [[ -n "${BODY_FILE}" ]]; then
+  cmd+=(--body-file "${BODY_FILE}")
+else
+  cmd+=(--body "${BODY}")
+fi
+
+labels="${LABELS//,/ }"
+for label in ${labels}; do
+  [[ -n "${label}" ]] && cmd+=(--label "${label}")
+done
+
+"${cmd[@]}"

--- a/scripts/github/issues/delete.sh
+++ b/scripts/github/issues/delete.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+
+if [[ -z "${REPO}" ]]; then
+  echo "Missing repository. Set REPO or GITHUB_REPOSITORY."
+  exit 1
+fi
+
+if [[ -z "${ISSUE_NUMBER}" ]]; then
+  echo "Missing ISSUE_NUMBER."
+  exit 1
+fi
+
+gh issue delete "${ISSUE_NUMBER}" --repo "${REPO}" --yes

--- a/scripts/github/issues/generate.py
+++ b/scripts/github/issues/generate.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate user stories and tasks from manifest")
+    parser.add_argument("manifest")
+    parser.add_argument("--repo")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--link-subissues", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["issues", "generate", "--file", args.manifest]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    if args.link_subissues:
+        cli_args += ["--link-subissues"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/issues/update.sh
+++ b/scripts/github/issues/update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+TITLE="${TITLE:-}"
+BODY="${BODY:-}"
+BODY_FILE="${BODY_FILE:-}"
+ADD_LABELS="${ADD_LABELS:-}"
+REMOVE_LABELS="${REMOVE_LABELS:-}"
+
+if [[ -z "${REPO}" ]]; then
+  echo "Missing repository. Set REPO or GITHUB_REPOSITORY."
+  exit 1
+fi
+
+if [[ -z "${ISSUE_NUMBER}" ]]; then
+  echo "Missing ISSUE_NUMBER."
+  exit 1
+fi
+
+cmd=(gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}")
+if [[ -n "${TITLE}" ]]; then
+  cmd+=(--title "${TITLE}")
+fi
+if [[ -n "${BODY_FILE}" ]]; then
+  cmd+=(--body-file "${BODY_FILE}")
+elif [[ -n "${BODY}" ]]; then
+  cmd+=(--body "${BODY}")
+fi
+
+add_flags() {
+  local flag="$1"
+  local raw="${2:-}"
+  raw="${raw//,/ }"
+  for item in ${raw}; do
+    [[ -n "${item}" ]] && cmd+=("${flag}" "${item}")
+  done
+}
+
+add_flags --add-label "${ADD_LABELS}"
+add_flags --remove-label "${REMOVE_LABELS}"
+
+"${cmd[@]}"

--- a/scripts/github/labels/sync.py
+++ b/scripts/github/labels/sync.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Sync repository labels from a manifest")
+    parser.add_argument("labels_file")
+    parser.add_argument("--repo")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["labels", "sync", "--file", args.labels_file]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/milestones/sync.py
+++ b/scripts/github/milestones/sync.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Create repository milestones from a manifest")
+    parser.add_argument("milestones_file")
+    parser.add_argument("--repo")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["milestones", "sync", "--file", args.milestones_file]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/project/create.py
+++ b/scripts/github/project/create.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Create GitHub Project v2 from project definition")
+    parser.add_argument("definition")
+    parser.add_argument("--repo")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = ["project", "create", "--file", args.definition]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/github/project/sync.py
+++ b/scripts/github/project/sync.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from governance_bootstrap.cli import main
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Configure a GitHub Project v2 and add repo issues to it")
+    parser.add_argument("project_definition")
+    parser.add_argument("--repo")
+    parser.add_argument("--owner")
+    parser.add_argument("--project-number", type=int, required=True)
+    parser.add_argument("--issue-state", default="open", choices=["open", "closed", "all"])
+    parser.add_argument("--link-subissues", action="store_true")
+    parser.add_argument("--only-link-subissues", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    cli_args = [
+        "project",
+        "sync",
+        "--file",
+        args.project_definition,
+        "--project-number",
+        str(args.project_number),
+        "--issue-state",
+        args.issue_state,
+    ]
+    if args.repo:
+        cli_args += ["--repo", args.repo]
+    if args.owner:
+        cli_args += ["--owner", args.owner]
+    if args.link_subissues:
+        cli_args += ["--link-subissues"]
+    if args.only_link_subissues:
+        cli_args += ["--only-link-subissues"]
+    if args.dry_run:
+        cli_args += ["--dry-run"]
+    raise SystemExit(main(cli_args))

--- a/scripts/run_signals.gd
+++ b/scripts/run_signals.gd
@@ -1,0 +1,4 @@
+extends Node
+
+signal request_next_chunk(chunk: Node)
+signal chunk_exited_screen(chunk: Node)

--- a/scripts/run_signals.gd.uid
+++ b/scripts/run_signals.gd.uid
@@ -1,0 +1,1 @@
+uid://kh1wjtlumm3i

--- a/take-your-pills_backlog_final.md
+++ b/take-your-pills_backlog_final.md
@@ -75,7 +75,7 @@ O time sai desta fase sabendo:
 ## Fase 1 — Fundação jogável + pré-produção de design
 **Janela sugerida:** de **22/04** até o checkpoint de **13/05**
 
-**Objetivo:** ter um runner jogável com movimento, colisão, derrota, restart, cenário inicial e loop base reconhecível.
+**Objetivo:** ter um runner jogável com chunks, colisão, derrota, restart, cenário inicial e loop base reconhecível.
 
 ### Entregas desta fase
 - guia visual mínimo do jogo


### PR DESCRIPTION
- Rebuild the main scene around `World -> Player + Chunks` so the player stays on screen while chunks stream horizontally.
- Add `ChunkManager` and a `RunSignals` autoload to manage chunk spawning, recycling, and run-state pause/resume.
- Add reusable chunk scenes for the stream layout and keep the player rendered above the level with a higher `z_index`.
- Remove the temporary coin and death-zone gameplay layer so the project stays focused on the runner skeleton only.
- Update the backlog and phase docs to match the chunk-stream implementation and current scope.