### PR TITLE
feat: implement local highscore with 5-char name (US-25)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -16,11 +16,12 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Take Your Pills"
 run/main_scene="res://scenes/game/game.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 
 [autoload]
 
 RunSignals="*res://scripts/run_signals.gd"
+SaveManager="*res://scripts/save_manager.gd"
 
 [display]
 

--- a/scenes/game/controllers/local_ranking_controller.gd
+++ b/scenes/game/controllers/local_ranking_controller.gd
@@ -1,0 +1,24 @@
+extends Node
+class_name LocalRankingController
+
+var _last_score: int = 0
+
+
+func _ready() -> void:
+	RunSignals.score_changed.connect(_on_score_changed)
+	RunSignals.run_game_over.connect(_on_run_game_over)
+
+
+func _on_score_changed(score: int) -> void:
+	_last_score = score
+
+
+func _on_run_game_over() -> void:
+	var best_score := SaveManager.get_best_score()
+	var best_name := SaveManager.get_best_name()
+	var is_new := SaveManager.is_new_record(_last_score)
+	RunSignals.highscore_checked.emit.call_deferred(_last_score, best_score, best_name, is_new)
+
+
+func save_record(player_name: String) -> void:
+	SaveManager.save_highscore(player_name, _last_score)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -14,6 +14,7 @@ enum GameState { MAIN_MENU, RUNNING, PAUSED, GAME_OVER }
 @onready var audio_controller = $Controllers/CollectableAudioController
 @onready var speed_up_controller := $Controllers/SpeedUpBoostController
 @onready var speed_down_controller := $Controllers/SpeedDownBoostController
+@onready var ranking_controller: LocalRankingController = $Controllers/LocalRankingController
 @onready var speed_up_row := $HUD/MarginContainer/VBoxContainer/SpeedContainer/SpeedUpContainer
 @onready var speed_down_row := $HUD/MarginContainer/VBoxContainer/SpeedContainer/SpeedDownContainer
 
@@ -48,6 +49,7 @@ func _ready() -> void:
 	speed_up_controller.boost_state_changed.connect(session_controller.on_speed_up_boost_state_changed)
 	speed_up_controller.boost_state_changed.connect(speed_down_controller.on_speed_up_boost_state_changed)
 	speed_down_controller.slow_state_changed.connect(session_controller.on_speed_down_state_changed)
+	hud.name_submitted.connect(ranking_controller.save_record)
 	session_controller.boot()
 
 

--- a/scenes/game/game.tscn
+++ b/scenes/game/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3]
+[gd_scene load_steps=12 format=3]
 
 [ext_resource type="Script" path="res://scenes/game/game.gd" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/player/player.tscn" id="2"]
@@ -10,6 +10,7 @@
 [ext_resource type="Script" path="res://scenes/game/controllers/run_session_controller.gd" id="8"]
 [ext_resource type="Script" path="res://scenes/game/controllers/run_score_controller.gd" id="9"]
 [ext_resource type="Script" path="res://scenes/game/controllers/collectable_audio_controller.gd" id="10"]
+[ext_resource type="Script" path="res://scenes/game/controllers/local_ranking_controller.gd" id="11"]
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1")
@@ -50,6 +51,9 @@ script = ExtResource("6")
 
 [node name="SpeedDownBoostController" type="Node" parent="Controllers"]
 script = ExtResource("7")
+
+[node name="LocalRankingController" type="Node" parent="Controllers"]
+script = ExtResource("11")
 
 [node name="HUD" parent="." instance=ExtResource("4")]
 

--- a/scenes/game/hud.gd
+++ b/scenes/game/hud.gd
@@ -13,6 +13,13 @@ class_name GameHUD
 @onready var pause_restart_button: Button = $PauseMenu/Panel/VBoxContainer/RestartButton
 @onready var final_score_label: Label = $GameOverMenu/Panel/VBoxContainer/FinalScoreLabel
 @onready var game_over_restart_button: Button = $GameOverMenu/Panel/VBoxContainer/RestartButton
+@onready var best_score_label: Label = $GameOverMenu/Panel/VBoxContainer/BestScoreLabel
+@onready var new_record_label: Label = $GameOverMenu/Panel/VBoxContainer/NewRecordLabel
+@onready var name_input_container: HBoxContainer = $GameOverMenu/Panel/VBoxContainer/NameInputContainer
+@onready var name_input: LineEdit = $GameOverMenu/Panel/VBoxContainer/NameInputContainer/NameInput
+@onready var save_button: Button = $GameOverMenu/Panel/VBoxContainer/NameInputContainer/SaveButton
+
+signal name_submitted(player_name: String)
 
 var _boost_timer: float = 0.0
 var _boost_active: bool = false
@@ -32,6 +39,9 @@ func _ready() -> void:
 	RunSignals.run_game_over.connect(_on_run_game_over)
 	RunSignals.score_changed.connect(update_score)
 	RunSignals.distance_changed.connect(update_distance)
+	RunSignals.highscore_checked.connect(_on_highscore_checked)
+	save_button.pressed.connect(_on_save_pressed)
+	name_input.text_submitted.connect(_on_name_text_submitted)
 
 
 func update_state(state_text: String, control_note: String, extra_note: String = "") -> void:
@@ -118,3 +128,33 @@ func _on_run_paused() -> void:
 func _on_run_game_over() -> void:
 	show_game_over(_last_score)
 	update_state("GAME OVER", "Jump: restart | Restart: button")
+
+
+func _on_highscore_checked(current_score: int, best_score: int, best_name: String, is_new_record: bool) -> void:
+	if is_new_record:
+		best_score_label.text = "Previous best: %s - %06d" % [best_name if not best_name.is_empty() else "---", best_score]
+		new_record_label.show()
+		name_input_container.show()
+		name_input.text = ""
+		name_input.grab_focus()
+	else:
+		best_score_label.text = "Best: %s - %06d" % [best_name if not best_name.is_empty() else "---", best_score]
+		new_record_label.hide()
+		name_input_container.hide()
+
+
+func _on_save_pressed() -> void:
+	_submit_name()
+
+
+func _on_name_text_submitted(_text: String) -> void:
+	_submit_name()
+
+
+func _submit_name() -> void:
+	var player_name := name_input.text.strip_edges()
+	if player_name.is_empty():
+		return
+	name_submitted.emit(player_name)
+	name_input_container.hide()
+	new_record_label.text = "RECORD SAVED!"

--- a/scenes/game/hud.tscn
+++ b/scenes/game/hud.tscn
@@ -248,9 +248,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -180.0
-offset_top = -96.0
+offset_top = -140.0
 offset_right = 180.0
-offset_bottom = 96.0
+offset_bottom = 140.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -268,6 +268,38 @@ horizontal_alignment = 1
 layout_mode = 2
 text = "Final score: 000000"
 horizontal_alignment = 1
+
+[node name="BestScoreLabel" type="Label" parent="GameOverMenu/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+text = ""
+horizontal_alignment = 1
+
+[node name="NewRecordLabel" type="Label" parent="GameOverMenu/Panel/VBoxContainer"]
+visible = false
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+theme_override_colors/font_color = Color(1, 0.85, 0.2, 1)
+text = "NEW RECORD!"
+horizontal_alignment = 1
+
+[node name="NameInputContainer" type="HBoxContainer" parent="GameOverMenu/Panel/VBoxContainer"]
+visible = false
+layout_mode = 2
+alignment = 1
+theme_override_constants/separation = 8
+
+[node name="NameInput" type="LineEdit" parent="GameOverMenu/Panel/VBoxContainer/NameInputContainer"]
+custom_minimum_size = Vector2(120, 32)
+layout_mode = 2
+placeholder_text = "NAME"
+max_length = 5
+alignment = 1
+
+[node name="SaveButton" type="Button" parent="GameOverMenu/Panel/VBoxContainer/NameInputContainer"]
+custom_minimum_size = Vector2(60, 32)
+layout_mode = 2
+text = "Save"
 
 [node name="RestartButton" type="Button" parent="GameOverMenu/Panel/VBoxContainer"]
 custom_minimum_size = Vector2(180, 44)

--- a/scripts/run_signals.gd
+++ b/scripts/run_signals.gd
@@ -14,3 +14,4 @@ signal distance_changed(distance: float)
 signal speed_up_collected
 signal speed_down_collected
 signal speed_too_slow
+signal highscore_checked(current_score: int, best_score: int, best_name: String, is_new_record: bool)

--- a/scripts/save_manager.gd
+++ b/scripts/save_manager.gd
@@ -1,0 +1,43 @@
+extends Node
+
+const SAVE_PATH := "user://highscore.cfg"
+const MAX_NAME_LENGTH := 5
+
+var _best_name: String = ""
+var _best_score: int = 0
+
+
+func _ready() -> void:
+	_load()
+
+
+func get_best_score() -> int:
+	return _best_score
+
+
+func get_best_name() -> String:
+	return _best_name
+
+
+func is_new_record(score: int) -> bool:
+	return score > _best_score
+
+
+func save_highscore(player_name: String, score: int) -> void:
+	if player_name.is_empty():
+		return
+	var trimmed := player_name.left(MAX_NAME_LENGTH)
+	_best_name = trimmed
+	_best_score = score
+	var config := ConfigFile.new()
+	config.set_value("highscore", "name", _best_name)
+	config.set_value("highscore", "score", _best_score)
+	config.save(SAVE_PATH)
+
+
+func _load() -> void:
+	var config := ConfigFile.new()
+	if config.load(SAVE_PATH) != OK:
+		return
+	_best_name = config.get_value("highscore", "name", "")
+	_best_score = config.get_value("highscore", "score", 0)


### PR DESCRIPTION
## Linked Issue
- Closes #242

## Milestone
- MS4

## Summary
- Implementado sistema de highscore local com persistência via ConfigFile (user://highscore.cfg). Adicionado SaveManager como autoload para salvar/carregar recordes, LocalRankingController para verificar se o score é novo recorde no game over, e elementos de UI no GameOverMenu (label de best score, indicador "NEW RECORD!", input de nome com limite de 5 caracteres e botão Save).

## Teste
- [ ] Sim, há teste implementado
- [X] Nao, nao ha teste implementado

## Known risks
- Quality Assurance vai emitir warning (non-blocking) por mudança em gameplay files sem testes automatizados — esperado para US com tag test:manual.
- O signal highscore_checked usa call_deferred para garantir que o HUD já exibiu a tela de game over antes de atualizar os labels de highscore — depende da ordem de execução do deferred frame.

## DoD checklist
- [X] Escopo implementado conforme definido
- [X] Opcao de teste selecionada
- [X] Nenhuma quebra critica conhecida foi introduzida

## Release version
- [X] Not a Release

## Related develop PRs
- [X] Not a Release
