### PR TITLE
feat: display highscore in main menu (US-26)

### DIFF
--- a/scenes/game/hud.gd
+++ b/scenes/game/hud.gd
@@ -9,6 +9,7 @@ class_name GameHUD
 @onready var pause_menu: Control = $PauseMenu
 @onready var game_over_menu: Control = $GameOverMenu
 @onready var start_button: Button = $MainMenu/Panel/VBoxContainer/StartButton
+@onready var menu_highscore_label: Label = $MainMenu/Panel/VBoxContainer/HighscoreLabel
 @onready var resume_button: Button = $PauseMenu/Panel/VBoxContainer/ResumeButton
 @onready var pause_restart_button: Button = $PauseMenu/Panel/VBoxContainer/RestartButton
 @onready var final_score_label: Label = $GameOverMenu/Panel/VBoxContainer/FinalScoreLabel
@@ -62,6 +63,7 @@ func update_distance(distance: float) -> void:
 
 func show_main_menu() -> void:
 	hide_menus()
+	_refresh_menu_highscore()
 	main_menu.show()
 
 
@@ -158,3 +160,12 @@ func _submit_name() -> void:
 	name_submitted.emit(player_name)
 	name_input_container.hide()
 	new_record_label.text = "RECORD SAVED!"
+
+
+func _refresh_menu_highscore() -> void:
+	var best_score := SaveManager.get_best_score()
+	var best_name := SaveManager.get_best_name()
+	if best_score > 0 and not best_name.is_empty():
+		menu_highscore_label.text = "Best: %s - %06d" % [best_name, best_score]
+	else:
+		menu_highscore_label.text = ""

--- a/scenes/game/hud.tscn
+++ b/scenes/game/hud.tscn
@@ -168,6 +168,12 @@ layout_mode = 2
 text = "Ready to run"
 horizontal_alignment = 1
 
+[node name="HighscoreLabel" type="Label" parent="MainMenu/Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+text = ""
+horizontal_alignment = 1
+
 [node name="StartButton" type="Button" parent="MainMenu/Panel/VBoxContainer"]
 custom_minimum_size = Vector2(180, 44)
 layout_mode = 2


### PR DESCRIPTION
## Linked Issue
- Closes #243

## Milestone
- MS4

## Summary
- Adicionado label de highscore no main menu que exibe o melhor score salvo e nome do jogador. Lê do SaveManager a cada exibição do menu. Complementa a US-25 que implementou o sistema de persistência e exibição no game over.

## Teste
- [ ] Sim, ha teste implementado
- [X] Nao, nao ha teste implementado

## Known risks
- Este PR depende do feat/US-25 ser mergeado primeiro (base branch é feat/US-25, não develop).

## DoD checklist
- [X] Escopo implementado conforme definido
- [X] Opcao de teste selecionada
- [X] Nenhuma quebra critica conhecida foi introduzida

## Release version
- [X] Not a Release

## Related develop PRs
- [X] Not a Release